### PR TITLE
[ECO-5137] Ensure room is ATTACHED before performing operation

### DIFF
--- a/chat-android/src/main/java/com/ably/chat/ErrorCodes.kt
+++ b/chat-android/src/main/java/com/ably/chat/ErrorCodes.kt
@@ -85,6 +85,11 @@ enum class ErrorCode(val code: Int) {
     RoomReleasedBeforeOperationCompleted(102_106),
 
     /**
+     * Room is not in valid state to perform any realtime operation.
+     */
+    RoomInInvalidState(102_107),
+
+    /**
      * Cannot perform operation because the previous operation failed.
      */
     PreviousOperationFailed(102_104),

--- a/chat-android/src/main/java/com/ably/chat/RoomStatus.kt
+++ b/chat-android/src/main/java/com/ably/chat/RoomStatus.kt
@@ -179,10 +179,12 @@ internal class RoomStatusEventEmitter(logger: Logger) : EventEmitter<RoomStatus,
 
 internal class DefaultRoomLifecycle(logger: Logger) : InternalRoomLifecycle {
 
+    @Volatile
     private var _status = RoomStatus.Initialized // CHA-RS3
     override val status: RoomStatus
         get() = _status
 
+    @Volatile
     private var _error: ErrorInfo? = null
     override val error: ErrorInfo?
         get() = _error

--- a/chat-android/src/main/java/com/ably/chat/Utils.kt
+++ b/chat-android/src/main/java/com/ably/chat/Utils.kt
@@ -221,8 +221,12 @@ fun lifeCycleException(
     cause: Throwable? = null,
 ): AblyException = createAblyException(errorInfo, cause)
 
-fun roomInvalidStateException(roomStatus: RoomStatus) =
-    ablyException("Can't perform operation, room is in an invalid state: $roomStatus", ErrorCode.RoomInInvalidState)
+fun roomInvalidStateException(roomId: String, roomStatus: RoomStatus, statusCode: Int) =
+    ablyException(
+        "Can't perform operation; the room '$roomId' is in an invalid state: $roomStatus",
+        ErrorCode.RoomInInvalidState,
+        statusCode,
+    )
 
 fun ablyException(
     errorMessage: String,

--- a/chat-android/src/main/java/com/ably/chat/Utils.kt
+++ b/chat-android/src/main/java/com/ably/chat/Utils.kt
@@ -221,6 +221,9 @@ fun lifeCycleException(
     cause: Throwable? = null,
 ): AblyException = createAblyException(errorInfo, cause)
 
+fun roomInvalidStateException(roomStatus: RoomStatus) =
+    ablyException("Can't perform operation, room is in an invalid state: $roomStatus", ErrorCode.RoomInInvalidState)
+
 fun ablyException(
     errorMessage: String,
     errorCode: ErrorCode,

--- a/chat-android/src/test/java/com/ably/chat/Sandbox.kt
+++ b/chat-android/src/test/java/com/ably/chat/Sandbox.kt
@@ -7,6 +7,8 @@ import io.ably.lib.realtime.ConnectionEvent
 import io.ably.lib.realtime.ConnectionState
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.cio.CIO
+import io.ktor.client.network.sockets.ConnectTimeoutException
+import io.ktor.client.network.sockets.SocketTimeoutException
 import io.ktor.client.plugins.HttpRequestRetry
 import io.ktor.client.plugins.HttpRequestTimeoutException
 import io.ktor.client.request.get
@@ -26,7 +28,9 @@ private val client = HttpClient(CIO) {
             !response.status.isSuccess()
         }
         retryOnExceptionIf { _, cause ->
-            cause is HttpRequestTimeoutException
+            cause is ConnectTimeoutException ||
+                cause is HttpRequestTimeoutException ||
+                cause is SocketTimeoutException
         }
         exponentialDelay()
     }

--- a/chat-android/src/test/java/com/ably/chat/room/RoomEnsureAttachedTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/room/RoomEnsureAttachedTest.kt
@@ -4,6 +4,7 @@ import com.ably.chat.ChatApi
 import com.ably.chat.DefaultRoom
 import com.ably.chat.DefaultRoomLifecycle
 import com.ably.chat.ErrorCode
+import com.ably.chat.HttpStatusCode
 import com.ably.chat.RoomLifecycle
 import com.ably.chat.RoomOptions
 import com.ably.chat.RoomStatus
@@ -72,7 +73,8 @@ class RoomEnsureAttachedTest {
             Assert.assertTrue(result.isFailure)
             val exception = result.exceptionOrNull() as AblyException
             Assert.assertEquals(ErrorCode.RoomInInvalidState.code, exception.errorInfo.code)
-            val errMsg = "Can't perform operation, room is in an invalid state: $invalidStatus"
+            Assert.assertEquals(HttpStatusCode.BadRequest, exception.errorInfo.statusCode)
+            val errMsg = "Can't perform operation; the room '$roomId' is in an invalid state: $invalidStatus"
             Assert.assertEquals(errMsg, exception.errorInfo.message)
         }
     }
@@ -160,7 +162,8 @@ class RoomEnsureAttachedTest {
             Assert.assertTrue(result.isFailure)
             val exception = result.exceptionOrNull() as AblyException
             Assert.assertEquals(ErrorCode.RoomInInvalidState.code, exception.errorInfo.code)
-            val errMsg = "Can't perform operation, room is in an invalid state: $invalidStatus"
+            Assert.assertEquals(HttpStatusCode.InternalServerError, exception.errorInfo.statusCode)
+            val errMsg = "Can't perform operation; the room '$roomId' is in an invalid state: $invalidStatus"
             Assert.assertEquals(errMsg, exception.errorInfo.message)
 
             Assert.assertEquals(0, room.StatusLifecycle.InternalEmitter.Filters.size) // Emitted event processed

--- a/chat-android/src/test/java/com/ably/chat/room/RoomEnsureAttachedTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/room/RoomEnsureAttachedTest.kt
@@ -1,0 +1,169 @@
+package com.ably.chat.room
+
+import com.ably.chat.ChatApi
+import com.ably.chat.DefaultRoom
+import com.ably.chat.DefaultRoomLifecycle
+import com.ably.chat.ErrorCode
+import com.ably.chat.RoomLifecycle
+import com.ably.chat.RoomOptions
+import com.ably.chat.RoomStatus
+import com.ably.chat.RoomStatusChange
+import com.ably.chat.assertWaiter
+import com.ably.chat.setPrivateField
+import io.ably.lib.types.AblyException
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.spyk
+import io.mockk.verify
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert
+import org.junit.Test
+
+/**
+ * Spec: CHA-RL9
+ * Common spec: CHA-PR3d, CHA-PR3h, CHA-PR10d, CHA-PR10h, CHA-PR6c, CHA-PR6h, CHA-PR6c, CHA-T2g
+ */
+class RoomEnsureAttachedTest {
+
+    private val clientId = "clientId"
+    private val logger = createMockLogger()
+    private val roomId = "1234"
+    private val mockRealtimeClient = createMockRealtimeClient()
+    private val chatApi = mockk<ChatApi>(relaxed = true)
+
+    @Test
+    fun `(CHA-PR3d, CHA-PR10d, CHA-PR6c, CHA-PR6c) When room is already ATTACHED, ensureAttached is a success`() = runTest {
+        val room = DefaultRoom(roomId, RoomOptions.default, mockRealtimeClient, chatApi, clientId, logger)
+        Assert.assertEquals(RoomStatus.Initialized, room.status)
+
+        // Set room status to ATTACHED
+        room.StatusLifecycle.setStatus(RoomStatus.Attached)
+        Assert.assertEquals(RoomStatus.Attached, room.status)
+
+        val result = kotlin.runCatching { room.ensureAttached() }
+        Assert.assertTrue(result.isSuccess)
+    }
+
+    @Suppress("MaximumLineLength")
+    @Test
+    fun `(CHA-PR3h, CHA-PR10h, CHA-PR6h, CHA-T2g) When room is not ATTACHED or ATTACHING, ensureAttached throws error with code RoomInInvalidState`() = runTest {
+        val room = DefaultRoom(roomId, RoomOptions.default, mockRealtimeClient, chatApi, clientId, logger)
+        Assert.assertEquals(RoomStatus.Initialized, room.status)
+
+        // List of room status other than ATTACHED/ATTACHING
+        val invalidStatuses = listOf(
+            RoomStatus.Initialized,
+            RoomStatus.Detaching,
+            RoomStatus.Detached,
+            RoomStatus.Suspended,
+            RoomStatus.Failed,
+            RoomStatus.Releasing,
+            RoomStatus.Released,
+        )
+
+        for (invalidStatus in invalidStatuses) {
+            room.StatusLifecycle.setStatus(invalidStatus)
+            Assert.assertEquals(invalidStatus, room.status)
+
+            // Check for exception when ensuring room ATTACHED
+            val result = kotlin.runCatching { room.ensureAttached() }
+            Assert.assertTrue(result.isFailure)
+            val exception = result.exceptionOrNull() as AblyException
+            Assert.assertEquals(ErrorCode.RoomInInvalidState.code, exception.errorInfo.code)
+            val errMsg = "Can't perform operation, room is in an invalid state: $invalidStatus"
+            Assert.assertEquals(errMsg, exception.errorInfo.message)
+        }
+    }
+
+    @Test
+    fun `(CHA-RL9a) When room is ATTACHING, subscribe once for next room status`() = runTest {
+        val room = DefaultRoom(roomId, RoomOptions.default, mockRealtimeClient, chatApi, clientId, logger)
+        Assert.assertEquals(RoomStatus.Initialized, room.status)
+
+        val roomLifecycleMock = spyk(DefaultRoomLifecycle(logger))
+        every {
+            roomLifecycleMock.onChangeOnce(any<RoomLifecycle.Listener>())
+        } answers {
+            val listener = firstArg<RoomLifecycle.Listener>()
+            listener.roomStatusChanged(RoomStatusChange(RoomStatus.Attached, RoomStatus.Attaching))
+        }
+        room.setPrivateField("statusLifecycle", roomLifecycleMock)
+
+        // Set room status to ATTACHING
+        room.StatusLifecycle.setStatus(RoomStatus.Attaching)
+        Assert.assertEquals(RoomStatus.Attaching, room.status)
+
+        room.ensureAttached()
+
+        verify(exactly = 1) {
+            roomLifecycleMock.onChangeOnce(any<RoomLifecycle.Listener>())
+        }
+    }
+
+    @Test
+    fun `(CHA-RL9b) When room is ATTACHING, subscription is registered, ensureAttached is a success`() = runTest {
+        val room = DefaultRoom(roomId, RoomOptions.default, mockRealtimeClient, chatApi, clientId, logger)
+        Assert.assertEquals(RoomStatus.Initialized, room.status)
+
+        // Set room status to ATTACHING
+        room.StatusLifecycle.setStatus(RoomStatus.Attaching)
+        Assert.assertEquals(RoomStatus.Attaching, room.status)
+
+        val ensureAttachJob = async { room.ensureAttached() }
+
+        // Wait for listener to be registered
+        assertWaiter { room.StatusLifecycle.InternalEmitter.Filters.size == 1 }
+
+        // Set ATTACHED status
+        room.StatusLifecycle.setStatus(RoomStatus.Attached)
+
+        val result = kotlin.runCatching { ensureAttachJob.await() }
+        Assert.assertTrue(result.isSuccess)
+
+        Assert.assertEquals(0, room.StatusLifecycle.InternalEmitter.Filters.size) // Emitted event processed
+    }
+
+    @Suppress("MaximumLineLength")
+    @Test
+    fun `(CHA-RL9c) When room is ATTACHING and subscription is registered and fails, ensureAttached throws error with code RoomInInvalidState`() = runTest {
+        val room = DefaultRoom(roomId, RoomOptions.default, mockRealtimeClient, chatApi, clientId, logger)
+        Assert.assertEquals(RoomStatus.Initialized, room.status)
+
+        // List of room status other than ATTACHED/ATTACHING
+        val invalidStatuses = listOf(
+            RoomStatus.Initialized,
+            RoomStatus.Detaching,
+            RoomStatus.Detached,
+            RoomStatus.Suspended,
+            RoomStatus.Failed,
+            RoomStatus.Releasing,
+            RoomStatus.Released,
+        )
+
+        for (invalidStatus in invalidStatuses) {
+            // Set room status to ATTACHING
+            room.StatusLifecycle.setStatus(RoomStatus.Attaching)
+            Assert.assertEquals(RoomStatus.Attaching, room.status)
+
+            val ensureAttachJob = async(SupervisorJob()) { room.ensureAttached() }
+
+            // Wait for listener to be registered
+            assertWaiter { room.StatusLifecycle.InternalEmitter.Filters.size == 1 }
+
+            // set invalid room status
+            room.StatusLifecycle.setStatus(invalidStatus)
+
+            // Check for exception when ensuring room ATTACHED
+            val result = kotlin.runCatching { ensureAttachJob.await() }
+            Assert.assertTrue(result.isFailure)
+            val exception = result.exceptionOrNull() as AblyException
+            Assert.assertEquals(ErrorCode.RoomInInvalidState.code, exception.errorInfo.code)
+            val errMsg = "Can't perform operation, room is in an invalid state: $invalidStatus"
+            Assert.assertEquals(errMsg, exception.errorInfo.message)
+
+            Assert.assertEquals(0, room.StatusLifecycle.InternalEmitter.Filters.size) // Emitted event processed
+        }
+    }
+}

--- a/chat-android/src/test/java/com/ably/chat/room/RoomTestHelpers.kt
+++ b/chat-android/src/test/java/com/ably/chat/room/RoomTestHelpers.kt
@@ -15,6 +15,7 @@ import com.ably.chat.Logger
 import com.ably.chat.Room
 import com.ably.chat.RoomLifecycleManager
 import com.ably.chat.RoomOptions
+import com.ably.chat.RoomStatusEventEmitter
 import com.ably.chat.Rooms
 import com.ably.chat.getPrivateField
 import com.ably.chat.invokePrivateSuspendMethod
@@ -22,6 +23,7 @@ import io.ably.lib.realtime.AblyRealtime
 import io.ably.lib.realtime.ChannelState
 import io.ably.lib.types.ClientOptions
 import io.ably.lib.types.ErrorInfo
+import io.ably.lib.util.EventEmitter
 import io.mockk.mockk
 import io.mockk.spyk
 import kotlinx.coroutines.CompletableDeferred
@@ -38,6 +40,13 @@ val Rooms.RoomReleaseDeferred get() = getPrivateField<MutableMap<String, Complet
 // Room mocks
 internal val Room.StatusLifecycle get() = getPrivateField<DefaultRoomLifecycle>("statusLifecycle")
 internal val Room.LifecycleManager get() = getPrivateField<RoomLifecycleManager>("lifecycleManager")
+
+// DefaultRoomLifecycle mocks
+internal val DefaultRoomLifecycle.InternalEmitter get() = getPrivateField<RoomStatusEventEmitter>("internalEmitter")
+
+// EventEmitter mocks
+internal val EventEmitter<*, *>.Listeners get() = getPrivateField<List<Any>>("listeners")
+internal val EventEmitter<*, *>.Filters get() = getPrivateField<Map<Any, Any>>("filters")
 
 // RoomLifeCycleManager Mocks
 internal fun RoomLifecycleManager.atomicCoroutineScope(): AtomicCoroutineScope = getPrivateField("atomicCoroutineScope")

--- a/chat-android/src/test/java/com/ably/chat/room/RoomTestHelpers.kt
+++ b/chat-android/src/test/java/com/ably/chat/room/RoomTestHelpers.kt
@@ -7,11 +7,13 @@ import com.ably.chat.ContributesToRoomLifecycle
 import com.ably.chat.DefaultMessages
 import com.ably.chat.DefaultOccupancy
 import com.ably.chat.DefaultPresence
+import com.ably.chat.DefaultRoom
 import com.ably.chat.DefaultRoomLifecycle
 import com.ably.chat.DefaultRoomReactions
 import com.ably.chat.DefaultTyping
 import com.ably.chat.LifecycleOperationPrecedence
 import com.ably.chat.Logger
+import com.ably.chat.RealtimeClient
 import com.ably.chat.Room
 import com.ably.chat.RoomLifecycleManager
 import com.ably.chat.RoomOptions
@@ -19,7 +21,9 @@ import com.ably.chat.RoomStatusEventEmitter
 import com.ably.chat.Rooms
 import com.ably.chat.getPrivateField
 import com.ably.chat.invokePrivateSuspendMethod
+import com.ably.chat.setPrivateField
 import io.ably.lib.realtime.AblyRealtime
+import io.ably.lib.realtime.Channel
 import io.ably.lib.realtime.ChannelState
 import io.ably.lib.types.ClientOptions
 import io.ably.lib.types.ErrorInfo
@@ -29,8 +33,36 @@ import io.mockk.spyk
 import kotlinx.coroutines.CompletableDeferred
 import io.ably.lib.realtime.Channel as AblyRealtimeChannel
 
-fun createMockRealtimeClient(): AblyRealtime = spyk(AblyRealtime(ClientOptions("id:key").apply { autoConnect = false }))
+const val DEFAULT_ROOM_ID = "1234"
+const val DEFAULT_CLIENT_ID = "clientId"
+const val DEFAULT_CHANNEL_NAME = "channel"
+
+fun createMockRealtimeClient(): AblyRealtime {
+    val realtimeClient = spyk(AblyRealtime(ClientOptions("id:key").apply { autoConnect = false }), recordPrivateCalls = true)
+    val mockChannels = spyk(realtimeClient.channels, recordPrivateCalls = true)
+    realtimeClient.setPrivateField("channels", mockChannels)
+    return realtimeClient
+}
+
+fun AblyRealtime.createMockChannel(channelName: String = DEFAULT_CHANNEL_NAME): Channel =
+    spyk(channels.get(channelName), recordPrivateCalls = true)
+
+internal fun createMockChatApi(
+    realtimeClient: RealtimeClient = createMockRealtimeClient(),
+    clientId: String = DEFAULT_CLIENT_ID,
+    logger: Logger = createMockLogger(),
+) = spyk(ChatApi(realtimeClient, clientId, logger), recordPrivateCalls = true)
+
 internal fun createMockLogger(): Logger = mockk<AndroidLogger>(relaxed = true)
+
+internal fun createMockRoom(
+    roomId: String = DEFAULT_ROOM_ID,
+    clientId: String = DEFAULT_CLIENT_ID,
+    realtimeClient: RealtimeClient = createMockRealtimeClient(),
+    chatApi: ChatApi = mockk<ChatApi>(relaxed = true),
+    logger: Logger = createMockLogger(),
+): DefaultRoom =
+    DefaultRoom(roomId, RoomOptions.default, realtimeClient, chatApi, clientId, logger)
 
 // Rooms mocks
 val Rooms.RoomIdToRoom get() = getPrivateField<MutableMap<String, Room>>("roomIdToRoom")
@@ -60,24 +92,17 @@ internal suspend fun RoomLifecycleManager.atomicRetry(exceptContributor: Contrib
     }.await()
 }
 
-fun createRoomFeatureMocks(roomId: String = "1234"): List<ContributesToRoomLifecycle> {
-    val clientId = "clientId"
-
+fun createRoomFeatureMocks(roomId: String = DEFAULT_ROOM_ID, clientId: String = DEFAULT_CLIENT_ID): List<ContributesToRoomLifecycle> {
     val realtimeClient = createMockRealtimeClient()
-    val chatApi = mockk<ChatApi>(relaxed = true)
+    val chatApi = createMockChatApi()
     val logger = createMockLogger()
+    val room = createMockRoom(roomId, clientId, realtimeClient, chatApi, logger)
 
     val messagesContributor = spyk(DefaultMessages(roomId, realtimeClient.channels, chatApi, logger), recordPrivateCalls = true)
-    val presenceContributor = spyk(
-        DefaultPresence(clientId, messagesContributor.channel, messagesContributor.channel.presence, logger),
-        recordPrivateCalls = true,
-    )
-    val occupancyContributor = spyk(DefaultOccupancy(realtimeClient.channels, chatApi, roomId, logger), recordPrivateCalls = true)
-    val typingContributor = spyk(
-        DefaultTyping(roomId, realtimeClient, clientId, RoomOptions.default.typing, logger),
-        recordPrivateCalls = true,
-    )
-    val reactionsContributor = spyk(DefaultRoomReactions(roomId, clientId, realtimeClient.channels, logger), recordPrivateCalls = true)
+    val presenceContributor = spyk(DefaultPresence(room), recordPrivateCalls = true)
+    val occupancyContributor = spyk(DefaultOccupancy(room), recordPrivateCalls = true)
+    val typingContributor = spyk(DefaultTyping(room), recordPrivateCalls = true)
+    val reactionsContributor = spyk(DefaultRoomReactions(room), recordPrivateCalls = true)
     return listOf(messagesContributor, presenceContributor, occupancyContributor, typingContributor, reactionsContributor)
 }
 


### PR DESCRIPTION
- Fixed #62 
- Added `ensureAttached` method to `DefaultRoom` as a common implementation to ensure room is `ATTACHED`.
- Updated Room Feature constructors to only accept `room` instance as constructor param since other params are not needed, updated related tests.
- Only exception is`Messages` feature, it's constructor is not updated and will be done as a part of https://github.com/ably-labs/ably-chat-kotlin/issues/68
- Updated related unit/integration tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced a new error code for invalid room states to enhance error handling.
	- Added a method to ensure the room is attached before performing operations, improving reliability.

- **Bug Fixes**
	- Enhanced error handling for various room states, ensuring proper exceptions are thrown.

- **Tests**
	- Implemented comprehensive tests for the new room attachment logic and error handling, ensuring robustness against invalid states.
	- Updated mock creation methods for improved test clarity and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->