### PR TITLE
chore: make suspended blocking call cancelable

### DIFF
--- a/chat-android/src/main/java/com/ably/chat/ChatApi.kt
+++ b/chat-android/src/main/java/com/ably/chat/ChatApi.kt
@@ -8,7 +8,7 @@ import io.ably.lib.types.ErrorInfo
 import io.ably.lib.types.Param
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
-import kotlin.coroutines.suspendCoroutine
+import kotlinx.coroutines.suspendCancellableCoroutine
 
 private const val API_PROTOCOL_VERSION = 3
 private const val PROTOCOL_VERSION_PARAM_NAME = "v"
@@ -124,7 +124,7 @@ internal class ChatApi(
         url: String,
         method: String,
         body: JsonElement? = null,
-    ): JsonElement? = suspendCoroutine { continuation ->
+    ): JsonElement? = suspendCancellableCoroutine { continuation ->
         val requestBody = body.toRequestBody()
         realtimeClient.requestAsync(
             method,
@@ -159,7 +159,7 @@ internal class ChatApi(
         method: String,
         params: List<Param> = listOf(),
         transform: (JsonElement) -> T,
-    ): PaginatedResult<T> = suspendCoroutine { continuation ->
+    ): PaginatedResult<T> = suspendCancellableCoroutine { continuation ->
         realtimeClient.requestAsync(
             method,
             url,

--- a/chat-android/src/main/java/com/ably/chat/PaginatedResult.kt
+++ b/chat-android/src/main/java/com/ably/chat/PaginatedResult.kt
@@ -6,7 +6,7 @@ import io.ably.lib.types.AsyncHttpPaginatedResponse
 import io.ably.lib.types.ErrorInfo
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
-import kotlin.coroutines.suspendCoroutine
+import kotlinx.coroutines.suspendCancellableCoroutine
 
 /**
  * Represents the result of a paginated query.
@@ -49,7 +49,7 @@ private class AsyncPaginatedResultWrapper<T>(
 ) : PaginatedResult<T> {
     override val items: List<T> = asyncPaginatedResult.items()?.map(transform) ?: emptyList()
 
-    override suspend fun next(): PaginatedResult<T> = suspendCoroutine { continuation ->
+    override suspend fun next(): PaginatedResult<T> = suspendCancellableCoroutine { continuation ->
         asyncPaginatedResult.next(object : AsyncHttpPaginatedResponse.Callback {
             override fun onResponse(response: AsyncHttpPaginatedResponse?) {
                 continuation.resume(response.toPaginatedResult(transform))

--- a/chat-android/src/main/java/com/ably/chat/Utils.kt
+++ b/chat-android/src/main/java/com/ably/chat/Utils.kt
@@ -15,7 +15,6 @@ import io.ably.lib.types.PresenceMessage
 import java.util.UUID
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
-import kotlin.coroutines.suspendCoroutine
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
@@ -23,7 +22,7 @@ import io.ably.lib.realtime.Presence as PubSubPresence
 
 const val AGENT_PARAMETER_NAME = "agent"
 
-suspend fun Channel.attachCoroutine() = suspendCoroutine { continuation ->
+suspend fun Channel.attachCoroutine() = suspendCancellableCoroutine { continuation ->
     attach(object : CompletionListener {
         override fun onSuccess() {
             continuation.resume(Unit)
@@ -35,7 +34,7 @@ suspend fun Channel.attachCoroutine() = suspendCoroutine { continuation ->
     })
 }
 
-suspend fun Channel.detachCoroutine() = suspendCoroutine { continuation ->
+suspend fun Channel.detachCoroutine() = suspendCancellableCoroutine { continuation ->
     detach(object : CompletionListener {
         override fun onSuccess() {
             continuation.resume(Unit)
@@ -47,7 +46,7 @@ suspend fun Channel.detachCoroutine() = suspendCoroutine { continuation ->
     })
 }
 
-suspend fun Channel.publishCoroutine(message: PubSubMessage) = suspendCoroutine { continuation ->
+suspend fun Channel.publishCoroutine(message: PubSubMessage) = suspendCancellableCoroutine { continuation ->
     publish(
         message,
         object : CompletionListener {
@@ -192,7 +191,7 @@ internal class DeferredValue<T> {
      * @return completed value
      */
     suspend fun await(): T {
-        val result = suspendCoroutine { continuation ->
+        val result = suspendCancellableCoroutine { continuation ->
             synchronized(lock) {
                 if (_completed) continuation.resume(value!!)
                 val observer: (T) -> Unit = {


### PR DESCRIPTION
Make suspended suspended blocking call cancelable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced coroutine handling for asynchronous operations in the chat functionality, allowing for better cancellation management.
  
- **Bug Fixes**
	- Improved robustness of operations related to message sending and channel management through updated coroutine mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->