### PR TITLE
[ECO-5180] feat: add release to maven central job

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,39 @@
+name: Manual Release to Maven Central
+
+on:
+  workflow_dispatch:
+
+jobs:
+  run-on-release:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Ensure the workflow is being run for a published release
+      - name: Validate Release
+        run: |
+          if [ -z "${{ github.event.release.tag_name }}" ]; then
+            echo "This workflow must be run in the context of a published release.";
+            exit 1;
+          fi
+          echo "Running workflow for release: ${{ github.event.release.tag_name }}";
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: 17
+          distribution: temurin
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v3
+
+      - name: Publish and release to Maven Central
+        run: ./gradlew publishAndReleaseToMavenCentral
+        env:
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_IN_MEMORY_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.SIGNING_KEY_ID }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,3 +8,59 @@
 4. Ensure you have added suitable tests and the test suite is passing(`./gradlew check`)
 5. Push to the branch (`git push origin my-new-feature`)
 6. Create a new Pull Request
+
+## Release Process
+
+### Prerequisites for Release
+
+Before starting the release process, ensure you have:
+
+1. Sonatype OSSRH account credentials configured in your `~/.gradle/gradle.properties`:
+   ```properties
+   mavenCentralUsername=user-token-username
+   mavenCentralPassword=user-token-password
+   ```
+2. GPG key for signing artifacts:
+- Generate a key pair if you don't have one: `gpg --gen-key`
+- Export the secret key to gradle.properties:
+    ```properties
+    signing.keyId=short-key-id
+    signing.password=key-password
+    signing.secretKeyRingFile=/path/to/.gnupg/secring.gpg
+    ```
+
+## Release Process
+
+This library uses [semantic versioning](http://semver.org/). For each release, the following needs to be done:
+
+1. Create a branch for the release, named like `release/1.2.4` (where `1.2.4` is what you're releasing, being the new version)
+2. Replace all references of the current version number with the new version number (check the [README.md](./README.md)
+   and [gradle.properties](./gradle.properties)) and commit the changes
+3. Run [`github_changelog_generator`](https://github.com/github-changelog-generator/github-changelog-generator) to automate the update of
+   the [CHANGELOG](./CHANGELOG.md). This may require some manual intervention, both in terms of how the command is run and how the change
+   log file is modified. Your mileage may vary:
+
+- The command you will need to run will look something like this:
+  `github_changelog_generator -u ably -p ably-chat-kotlin --since-tag v1.2.3 --output delta.md --token $GITHUB_TOKEN_WITH_REPO_ACCESS`.
+  Generate token [here](https://github.com/settings/tokens/new?description=GitHub%20Changelog%20Generator%20token).
+- Using the command above, `--output delta.md` writes changes made after `--since-tag` to a new file.
+- The contents of that new file (`delta.md`) then need to be manually inserted at the top of the `CHANGELOG.md`, changing the "Unreleased"
+  heading and linking with the current version numbers.
+- Also ensure that the "Full Changelog" link points to the new version tag instead of the `HEAD`.
+
+4. Commit [CHANGELOG](./CHANGELOG.md)
+5. Make a PR against `main`
+6. Once the PR is approved, merge it into `main`
+7. From the updated `main` branch on your local workstation, assemble and upload:
+    ```sh
+      ./gradlew publishAndReleaseToMavenCentral
+    ```
+    - Verify the upload was successful by checking the Maven Central repository
+    - If the upload fails, check the Sonatype staging repository for any validation errors
+    - Common issues include:
+        - Missing POM file information
+        - Invalid signatures
+        - Incomplete Javadoc
+8. Add a tag and push to origin - e.g.: `git tag v1.2.4 && git push origin v1.2.4`
+9. Create the release on Github including populating the release notes
+10. Create the entry on the [Ably Changelog](https://changelog.ably.com/) (via [headwayapp](https://headwayapp.co/))

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,6 @@
+import com.vanniktech.maven.publish.MavenPublishBaseExtension
+import com.vanniktech.maven.publish.SonatypeHost
+
 plugins {
     alias(libs.plugins.detekt)
     alias(libs.plugins.android.library) apply false
@@ -5,6 +8,7 @@ plugins {
     alias(libs.plugins.android.kotlin) apply false
     alias(libs.plugins.compose.compiler) apply false
     alias(libs.plugins.build.config) apply false
+    alias(libs.plugins.maven.publish) apply false
 }
 
 dependencies {
@@ -42,4 +46,13 @@ tasks.detekt.configure {
 
 tasks.register("check") {
     // register check task for the root project so our detekt task will run on `gradlew check`
+}
+
+configure(subprojects) {
+    pluginManager.withPlugin("com.vanniktech.maven.publish") {
+        extensions.configure<MavenPublishBaseExtension> {
+            publishToMavenCentral(SonatypeHost.S01)
+            signAllPublications()
+        }
+    }
 }

--- a/chat-android/build.gradle.kts
+++ b/chat-android/build.gradle.kts
@@ -1,3 +1,5 @@
+import com.android.build.gradle.tasks.SourceJarTask
+import com.github.gmazzo.buildconfig.BuildConfigTask
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 
 plugins {
@@ -5,9 +7,10 @@ plugins {
     alias(libs.plugins.android.kotlin)
     alias(libs.plugins.build.config)
     alias(libs.plugins.kover)
+    alias(libs.plugins.maven.publish)
 }
 
-val version = libs.versions.ably.chat.get()
+val version = property("VERSION_NAME")
 
 android {
     namespace = "com.ably.chat"
@@ -31,12 +34,12 @@ android {
 
     compileOptions {
         isCoreLibraryDesugaringEnabled = true
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
     }
 
     kotlinOptions {
-        jvmTarget = "17"
+        jvmTarget = "1.8"
     }
 }
 
@@ -65,4 +68,8 @@ tasks.withType<Test>().configureEach {
     testLogging {
         exceptionFormat = TestExceptionFormat.FULL
     }
+}
+
+tasks.withType<SourceJarTask>().configureEach {
+    dependsOn(tasks.withType<BuildConfigTask>())
 }

--- a/chat-android/gradle.properties
+++ b/chat-android/gradle.properties
@@ -1,0 +1,4 @@
+POM_ARTIFACT_ID=chat-android
+POM_NAME=Ably Chat Android client library SDK
+POM_DESCRIPTION=An Android client library SDK for the Ably Chat product.
+POM_PACKAGING=aar

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,4 +16,21 @@ org.gradle.parallel=true
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
 android.useAndroidX=true
 
-android.enableBuildConfigAsBytecode=true
+# Maven Publish properties:
+GROUP=com.ably.chat
+VERSION_NAME=0.1.0-SNAPSHOT
+
+POM_INCEPTION_YEAR=2024
+POM_URL=https://github.com/ably/ably-chat-kotlin
+POM_SCM_URL=https://github.com/ably/ably-chat-kotlin/
+POM_SCM_CONNECTION=scm:git:git://github.com/ably/ably-chat-kotlin.git
+POM_SCM_DEV_CONNECTION=scm:git:git@github.com:ably/ably-chat-kotlin.git
+
+POM_LICENSE_NAME=The Apache Software License, Version 2.0
+POM_LICENSE_URL=https://raw.github.com/ably/ably-chat-kotlin/main/LICENSE
+POM_LICENSE_DIST=repo
+
+POM_DEVELOPER_ID=ably
+POM_DEVELOPER_NAME=Ably
+POM_DEVELOPER_URL=https://github.com/ably/
+SONATYPE_STAGING_PROFILE=com.ably

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,6 @@
 # https://docs.gradle.org/current/userguide/platforms.html#sub::toml-dependencies-format
 
 [versions]
-ably-chat = "0.0.1"
 ably = "1.2.46"
 desugar-jdk-libs = "2.1.2"
 junit = "4.13.2"
@@ -20,7 +19,7 @@ compose-bom = "2024.06.00"
 gson = "2.11.0"
 mockk = "1.13.13"
 coroutine = "1.9.0"
-build-config = "5.4.0"
+build-config = "5.5.1"
 ktor = "3.0.1"
 
 [libraries]
@@ -47,7 +46,6 @@ androidx-material3 = { group = "androidx.compose.material3", name = "material3" 
 
 gson = { group = "com.google.code.gson", name = "gson", version.ref = "gson" }
 
-konfetti-compose = { module = "nl.dionsegijn:konfetti-compose", version.ref = "konfetti-compose" }
 mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
 
 coroutine-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "coroutine" }
@@ -67,3 +65,4 @@ android-application = { id = "com.android.application", version.ref = "agp" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 build-config = { id = "com.github.gmazzo.buildconfig", version.ref = "build-config" }
 kover = { id = "org.jetbrains.kotlinx.kover", version = "0.9.0-RC" }
+maven-publish = { id = "com.vanniktech.maven.publish", version = "0.30.0" }


### PR DESCRIPTION
- Added settings for maven publishing
- Added github action for publishing (for now it's manual, to make sure it's working, later I want to make it automatic)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced a manual GitHub Actions workflow for releasing to Maven Central.
	- Added a "Release Process" section in the contributing guidelines to assist contributors in managing releases.

- **Improvements**
	- Enhanced build configuration to support Maven publishing across subprojects.
	- Updated project properties for better metadata management during publishing.

- **Dependency Updates**
	- Updated build configuration version and added a new publishing plugin.

These changes streamline the release process and improve project maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->