### PR TITLE
[ECO-5147][CHA-RC3] Fix shared channel options for messages feature

### DIFF
--- a/chat-android/src/main/java/com/ably/chat/Occupancy.kt
+++ b/chat-android/src/main/java/com/ably/chat/Occupancy.kt
@@ -81,21 +81,9 @@ internal class DefaultOccupancy(
 
     override val detachmentErrorCode: ErrorCode = ErrorCode.OccupancyDetachmentFailed
 
-    private val realtimeChannels = room.realtimeClient.channels
-
     private val logger = room.roomLogger.withContext(tag = "Occupancy")
 
-    // (CHA-O1)
-    private val messagesChannelName = "${room.roomId}::\$chat::\$chatMessages"
-
-    override val channel: Channel = realtimeChannels.get(
-        messagesChannelName,
-        ChatChannelOptions {
-            params = mapOf(
-                "occupancy" to "metrics",
-            )
-        },
-    )
+    override val channel: Channel = room.messages.channel
 
     private val listeners: MutableList<Occupancy.Listener> = CopyOnWriteArrayList()
 

--- a/chat-android/src/main/java/com/ably/chat/Room.kt
+++ b/chat-android/src/main/java/com/ably/chat/Room.kt
@@ -127,12 +127,7 @@ internal class DefaultRoom(
     private val roomScope =
         CoroutineScope(Dispatchers.Default.limitedParallelism(1) + CoroutineName(roomId) + SupervisorJob())
 
-    override val messages = DefaultMessages(
-        roomId = roomId,
-        realtimeChannels = realtimeClient.channels,
-        chatApi = chatApi,
-        logger = roomLogger.withContext(tag = "Messages"),
-    )
+    override val messages = DefaultMessages(room = this)
 
     private var _presence: Presence? = null
     override val presence: Presence

--- a/chat-android/src/test/java/com/ably/chat/room/RoomFeatureSharedChannelTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/room/RoomFeatureSharedChannelTest.kt
@@ -1,0 +1,67 @@
+package com.ably.chat.room
+
+import io.ably.lib.realtime.buildRealtimeChannel
+import io.ably.lib.types.ChannelMode
+import io.ably.lib.types.ChannelOptions
+import io.mockk.every
+import io.mockk.verify
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert
+import org.junit.Test
+
+/**
+ * Test to check shared channel for room features.
+ * Spec: CHA-RC3
+ */
+class RoomFeatureSharedChannelTest {
+
+    @Test
+    fun `(CHA-RC3a) Features with shared channel should call channels#get only once with combined modes+options`() = runTest {
+        val mockRealtimeClient = createMockRealtimeClient()
+        val capturedChannelOptions = mutableListOf<ChannelOptions>()
+
+        every {
+            mockRealtimeClient.channels.get("1234::\$chat::\$chatMessages", any<ChannelOptions>())
+        } answers {
+            capturedChannelOptions.add(secondArg())
+            buildRealtimeChannel()
+        }
+
+        // Create room with all feature enabled,
+        val room = createMockRoom(realtimeClient = mockRealtimeClient)
+
+        // Messages, occupancy and presence features uses the same channel
+        Assert.assertEquals(room.messages.channel, room.presence.channel)
+        Assert.assertEquals(room.messages.channel, room.occupancy.channel)
+
+        // Reactions and typing uses independent channel
+        Assert.assertNotEquals(room.messages.channel, room.typing.channel)
+        Assert.assertNotEquals(room.messages.channel, room.reactions.channel)
+        Assert.assertNotEquals(room.reactions.channel, room.typing.channel)
+
+        Assert.assertEquals(1, capturedChannelOptions.size)
+        // Check for set presence modes
+        Assert.assertEquals(2, capturedChannelOptions[0].modes.size)
+        Assert.assertEquals(ChannelMode.presence, capturedChannelOptions[0].modes[0])
+        Assert.assertEquals(ChannelMode.presence_subscribe, capturedChannelOptions[0].modes[1])
+        // Check if occupancy matrix is set
+        Assert.assertEquals("metrics", capturedChannelOptions[0].params["occupancy"])
+
+        // channels.get is called only once for Messages, occupancy and presence since they share the same channel
+        verify(exactly = 1) {
+            mockRealtimeClient.channels.get("1234::\$chat::\$chatMessages", any<ChannelOptions>())
+        }
+        // channels.get called separately for typing since it uses it's own channel
+        verify(exactly = 1) {
+            mockRealtimeClient.channels.get("1234::\$chat::\$typingIndicators", any<ChannelOptions>())
+        }
+        // channels.get called separately for reactions since it uses it's own channel
+        verify(exactly = 1) {
+            mockRealtimeClient.channels.get("1234::\$chat::\$reactions", any<ChannelOptions>())
+        }
+        // channels.get is called thrice for all features
+        verify(exactly = 3) {
+            mockRealtimeClient.channels.get(any<String>(), any<ChannelOptions>())
+        }
+    }
+}

--- a/chat-android/src/test/java/com/ably/chat/room/RoomTestHelpers.kt
+++ b/chat-android/src/test/java/com/ably/chat/room/RoomTestHelpers.kt
@@ -98,7 +98,7 @@ fun createRoomFeatureMocks(roomId: String = DEFAULT_ROOM_ID, clientId: String = 
     val logger = createMockLogger()
     val room = createMockRoom(roomId, clientId, realtimeClient, chatApi, logger)
 
-    val messagesContributor = spyk(DefaultMessages(roomId, realtimeClient.channels, chatApi, logger), recordPrivateCalls = true)
+    val messagesContributor = spyk(DefaultMessages(room), recordPrivateCalls = true)
     val presenceContributor = spyk(DefaultPresence(room), recordPrivateCalls = true)
     val occupancyContributor = spyk(DefaultOccupancy(room), recordPrivateCalls = true)
     val typingContributor = spyk(DefaultTyping(room), recordPrivateCalls = true)


### PR DESCRIPTION
- Fixed #68 
1. Updated DefaultMessages constructor to accept 'room` as the only argument
2. Updated DefaultMessages.channel to accept merged options across shared features
3. Added extention method to 'RoomOptions', messagesChannelOptions, merged modes from all shared channels ( presence and occupancy )
4. Fixed unit/integration tests related to Messages feature

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced messaging functionality with improved error handling and dynamic channel configuration.
  - Simplified channel initialization for occupancy management.
  - Added a test class for validating shared channel functionality within room features.

- **Bug Fixes**
  - Improved error reporting for accessing uninitialized properties in room management.

- **Tests**
  - Streamlined mock creation for message handling tests.
  - Added new tests to ensure shared channel logic functions correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->