### PR TITLE
fix: add missing channel modes for message channel

### DIFF
--- a/chat-android/src/main/java/com/ably/chat/RoomOptions.kt
+++ b/chat-android/src/main/java/com/ably/chat/RoomOptions.kt
@@ -121,14 +121,20 @@ internal fun RoomOptions.validateRoomOptions() {
 internal fun RoomOptions.messagesChannelOptions(): ChannelOptions {
     return ChatChannelOptions {
         presence?.let {
-            val presenceModes = mutableListOf<ChannelMode>()
-            if (presence.enter) {
-                presenceModes.add(ChannelMode.presence)
+            val channelModes = buildList {
+                // We should have this modes for regular messages
+                add(ChannelMode.publish)
+                add(ChannelMode.subscribe)
+
+                if (presence.enter) {
+                    add(ChannelMode.presence)
+                }
+                if (presence.subscribe) {
+                    add(ChannelMode.presence_subscribe)
+                }
             }
-            if (presence.subscribe) {
-                presenceModes.add(ChannelMode.presence_subscribe)
-            }
-            modes = presenceModes.toTypedArray()
+
+            modes = channelModes.toTypedArray()
         }
         occupancy?.let {
             params = mapOf(

--- a/chat-android/src/test/java/com/ably/chat/SandboxTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/SandboxTest.kt
@@ -109,11 +109,31 @@ class SandboxTest {
     }
 
     @Test
-    fun `should be able to send and retrieve messages`() = runTest {
+    fun `should be able to send and retrieve messages without room features`() = runTest {
         val chatClient = sandbox.createSandboxChatClient()
         val roomId = UUID.randomUUID().toString()
 
         val room = chatClient.rooms.get(roomId)
+
+        room.attach()
+
+        val messageEvent = CompletableDeferred<MessageEvent>()
+
+        room.messages.subscribe { messageEvent.complete(it) }
+        room.messages.send("hello")
+
+        assertEquals(
+            "hello",
+            messageEvent.await().message.text,
+        )
+    }
+
+    @Test
+    fun `should be able to send and retrieve messages with all room features enabled`() = runTest {
+        val chatClient = sandbox.createSandboxChatClient()
+        val roomId = UUID.randomUUID().toString()
+
+        val room = chatClient.rooms.get(roomId, RoomOptions.default)
 
         room.attach()
 

--- a/chat-android/src/test/java/com/ably/chat/room/RoomFeatureSharedChannelTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/room/RoomFeatureSharedChannelTest.kt
@@ -41,9 +41,11 @@ class RoomFeatureSharedChannelTest {
 
         Assert.assertEquals(1, capturedChannelOptions.size)
         // Check for set presence modes
-        Assert.assertEquals(2, capturedChannelOptions[0].modes.size)
-        Assert.assertEquals(ChannelMode.presence, capturedChannelOptions[0].modes[0])
-        Assert.assertEquals(ChannelMode.presence_subscribe, capturedChannelOptions[0].modes[1])
+        Assert.assertEquals(4, capturedChannelOptions[0].modes.size)
+        Assert.assertEquals(ChannelMode.publish, capturedChannelOptions[0].modes[0])
+        Assert.assertEquals(ChannelMode.subscribe, capturedChannelOptions[0].modes[1])
+        Assert.assertEquals(ChannelMode.presence, capturedChannelOptions[0].modes[2])
+        Assert.assertEquals(ChannelMode.presence_subscribe, capturedChannelOptions[0].modes[3])
         // Check if occupancy matrix is set
         Assert.assertEquals("metrics", capturedChannelOptions[0].params["occupancy"])
 


### PR DESCRIPTION
Fix bug then room with all features enabled stops receiving messages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced message handling with new test scenarios for room configurations.

- **Bug Fixes**
	- Streamlined logic for constructing channel modes in message options.

- **Tests**
	- Updated existing test for message retrieval to clarify room feature context.
	- Added a new test for message functionality with all room features enabled.
	- Improved assertions in tests to verify correct channel modes for shared channels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->