### PR TITLE
[ECO-5063] feat: add SDK tracking for Rest and Realtime calls 

### DIFF
--- a/chat-android/build.gradle.kts
+++ b/chat-android/build.gradle.kts
@@ -59,6 +59,8 @@ dependencies {
     testImplementation(libs.mockk)
     testImplementation(libs.coroutine.test)
     testImplementation(libs.bundles.ktor.client)
+    testImplementation(libs.nanohttpd)
+    testImplementation(libs.turbine)
     androidTestImplementation(libs.androidx.test.core)
     androidTestImplementation(libs.androidx.test.runner)
     androidTestImplementation(libs.androidx.junit)

--- a/chat-android/build.gradle.kts
+++ b/chat-android/build.gradle.kts
@@ -51,6 +51,7 @@ buildConfig {
 
 dependencies {
     api(libs.ably.android)
+    implementation(libs.ably.pubsub.adapter)
     implementation(libs.gson)
     implementation(libs.coroutine.core)
 

--- a/chat-android/src/main/java/com/ably/chat/Discontinuities.kt
+++ b/chat-android/src/main/java/com/ably/chat/Discontinuities.kt
@@ -1,17 +1,17 @@
 package com.ably.chat
 
+import com.ably.pubsub.RealtimeChannel
 import io.ably.lib.types.ErrorInfo
 import io.ably.lib.util.EventEmitter
-import io.ably.lib.realtime.ChannelBase as AblyRealtimeChannel
 
 /**
  * Represents an object that has a channel and therefore may care about discontinuities.
  */
-interface HandlesDiscontinuity {
+internal interface HandlesDiscontinuity {
     /**
      * The channel that this object is associated with.
      */
-    val channel: AblyRealtimeChannel
+    val channelWrapper: RealtimeChannel
 
     /**
      * Called when a discontinuity is detected on the channel.

--- a/chat-android/src/main/java/com/ably/chat/Occupancy.kt
+++ b/chat-android/src/main/java/com/ably/chat/Occupancy.kt
@@ -2,6 +2,7 @@
 
 package com.ably.chat
 
+import com.ably.pubsub.RealtimeChannel
 import com.google.gson.JsonObject
 import com.google.gson.JsonPrimitive
 import io.ably.lib.realtime.Channel
@@ -85,6 +86,8 @@ internal class DefaultOccupancy(
 
     override val channel: Channel = room.messages.channel
 
+    override val channelWrapper: RealtimeChannel = room.messages.channelWrapper
+
     private val listeners: MutableList<Occupancy.Listener> = CopyOnWriteArrayList()
 
     private val eventBus = MutableSharedFlow<OccupancyEvent>(
@@ -108,11 +111,7 @@ internal class DefaultOccupancy(
             internalChannelListener(it)
         }
 
-        channel.subscribe(occupancyListener)
-
-        occupancySubscription = Subscription {
-            channel.unsubscribe(occupancyListener)
-        }
+        occupancySubscription = channelWrapper.subscribe(occupancyListener).asChatSubscription()
     }
 
     // (CHA-O4)

--- a/chat-android/src/main/java/com/ably/chat/Presence.kt
+++ b/chat-android/src/main/java/com/ably/chat/Presence.kt
@@ -2,6 +2,8 @@
 
 package com.ably.chat
 
+import com.ably.pubsub.RealtimeChannel
+import com.ably.pubsub.RealtimePresence
 import com.google.gson.JsonElement
 import com.google.gson.JsonObject
 import io.ably.lib.realtime.Channel
@@ -146,9 +148,11 @@ internal class DefaultPresence(
 
     override val channel: Channel = room.messages.channel
 
+    override val channelWrapper: RealtimeChannel = room.messages.channelWrapper
+
     private val logger = room.logger.withContext(tag = "Presence")
 
-    private val presence = channel.presence
+    private val presence: RealtimePresence = channelWrapper.presence
 
     override suspend fun get(waitForSync: Boolean, clientId: String?, connectionId: String?): List<PresenceMember> {
         room.ensureAttached(logger) // CHA-PR6d, CHA-PR6c, CHA-PR6h
@@ -190,11 +194,7 @@ internal class DefaultPresence(
             listener.onEvent(presenceEvent)
         }
 
-        presence.subscribe(presenceListener)
-
-        return Subscription {
-            presence.unsubscribe(presenceListener)
-        }
+        return presence.subscribe(presenceListener).asChatSubscription()
     }
 
     private fun wrapInUserCustomData(data: PresenceData?) = data?.let {

--- a/chat-android/src/main/java/com/ably/chat/Room.kt
+++ b/chat-android/src/main/java/com/ably/chat/Room.kt
@@ -1,5 +1,6 @@
 package com.ably.chat
 
+import com.ably.pubsub.RealtimeClient
 import io.ably.lib.types.ErrorInfo
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineName
@@ -264,6 +265,7 @@ internal class DefaultRoom(
                             featureLogger.debug("ensureAttached(); waiting complete, room is now ATTACHED")
                             attachDeferred.complete(Unit)
                         }
+
                         RoomStatus.Attaching -> statusLifecycle.onChangeOnce {
                             if (it.current == RoomStatus.Attached) {
                                 featureLogger.debug("ensureAttached(); waiting complete, room is now ATTACHED")
@@ -275,6 +277,7 @@ internal class DefaultRoom(
                                 attachDeferred.completeExceptionally(exception)
                             }
                         }
+
                         else -> {
                             featureLogger.error(
                                 "ensureAttached(); waiting complete, room ATTACHING failed with error: ${statusLifecycle.error}",

--- a/chat-android/src/main/java/com/ably/chat/Rooms.kt
+++ b/chat-android/src/main/java/com/ably/chat/Rooms.kt
@@ -1,5 +1,6 @@
 package com.ably.chat
 
+import com.ably.pubsub.RealtimeClient
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers

--- a/chat-android/src/test/java/com/ably/chat/ChatApiTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/ChatApiTest.kt
@@ -1,5 +1,6 @@
 package com.ably.chat
 
+import com.ably.pubsub.RealtimeClient
 import com.google.gson.JsonObject
 import io.ably.lib.types.AblyException
 import io.ably.lib.types.MessageAction

--- a/chat-android/src/test/java/com/ably/chat/MessagesTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/MessagesTest.kt
@@ -1,16 +1,16 @@
 package com.ably.chat
 
-import com.ably.chat.room.createMockChannel
+import com.ably.annotations.InternalAPI
 import com.ably.chat.room.createMockChatApi
+import com.ably.chat.room.createMockRealtimeChannel
 import com.ably.chat.room.createMockRealtimeClient
 import com.ably.chat.room.createMockRoom
 import com.google.gson.JsonObject
-import io.ably.lib.realtime.Channel
-import io.ably.lib.realtime.ChannelBase
 import io.ably.lib.realtime.ChannelState
 import io.ably.lib.realtime.ChannelStateListener
 import io.ably.lib.realtime.buildChannelStateChange
 import io.ably.lib.types.AblyException
+import io.ably.lib.types.ChannelProperties
 import io.ably.lib.types.MessageAction
 import io.ably.lib.types.MessageExtras
 import io.mockk.every
@@ -28,18 +28,17 @@ import org.junit.Test
 class MessagesTest {
 
     private val realtimeClient = createMockRealtimeClient()
-    private val realtimeChannel = realtimeClient.createMockChannel()
 
     private lateinit var messages: DefaultMessages
     private val channelStateListenerSlot = slot<ChannelStateListener>()
 
+    @OptIn(InternalAPI::class)
     @Before
     fun setUp() {
-        every { realtimeClient.channels.get(any(), any()) } returns realtimeChannel
-        every { realtimeChannel.on(capture(channelStateListenerSlot)) } answers {
-            println("Channel state listener registered")
-        }
-
+        val channel = createMockRealtimeChannel("room1::\$chat::\$chatMessages")
+        every { channel.javaChannel.on(capture(channelStateListenerSlot)) } returns mockk()
+        val channels = realtimeClient.channels
+        every { channels.get("room1::\$chat::\$chatMessages", any()) } returns channel
         val chatApi = createMockChatApi(realtimeClient)
         val room = createMockRoom("room1", realtimeClient = realtimeClient, chatApi = chatApi)
 
@@ -90,9 +89,7 @@ class MessagesTest {
     fun `should be able to subscribe to incoming messages`() = runTest {
         val pubSubMessageListenerSlot = slot<PubSubMessageListener>()
 
-        every { realtimeChannel.subscribe("chat.message", capture(pubSubMessageListenerSlot)) } answers {
-            println("Pub/Sub message listener registered")
-        }
+        every { messages.channelWrapper.subscribe("chat.message", capture(pubSubMessageListenerSlot)) } returns mockk()
 
         val deferredValue = CompletableDeferred<MessageEvent>()
 
@@ -100,7 +97,7 @@ class MessagesTest {
             deferredValue.complete(it)
         }
 
-        verify { realtimeChannel.subscribe("chat.message", any()) }
+        verify { messages.channelWrapper.subscribe("chat.message", any()) }
 
         pubSubMessageListenerSlot.captured.onMessage(
             PubSubMessage().apply {
@@ -168,13 +165,13 @@ class MessagesTest {
      */
     @Test
     fun `every subscription should have own channel serial`() = runTest {
-        messages.channel.properties.channelSerial = "channel-serial-1"
-        messages.channel.state = ChannelState.attached
+        every { messages.channelWrapper.state } returns ChannelState.attached
+        every { messages.channelWrapper.properties } returns ChannelProperties().apply { channelSerial = "channel-serial-1" }
 
         val subscription1 = (messages.subscribe {}) as DefaultMessagesSubscription
         assertEquals("channel-serial-1", subscription1.fromSerialProvider().await())
 
-        messages.channel.properties.channelSerial = "channel-serial-2"
+        every { messages.channelWrapper.properties } returns ChannelProperties().apply { channelSerial = "channel-serial-2" }
         val subscription2 = (messages.subscribe {}) as DefaultMessagesSubscription
 
         assertEquals("channel-serial-2", subscription2.fromSerialProvider().await())
@@ -186,14 +183,16 @@ class MessagesTest {
      */
     @Test
     fun `subscription should update channel serial after reattach with resume = false`() = runTest {
-        messages.channel.properties.channelSerial = "channel-serial-1"
-        messages.channel.state = ChannelState.attached
+        every { messages.channelWrapper.state } returns ChannelState.attached
+        every { messages.channelWrapper.properties } returns ChannelProperties().apply { channelSerial = "channel-serial-1" }
 
         val subscription1 = (messages.subscribe {}) as DefaultMessagesSubscription
         assertEquals("channel-serial-1", subscription1.fromSerialProvider().await())
 
-        messages.channel.properties.channelSerial = "channel-serial-2"
-        messages.channel.properties.attachSerial = "attach-serial-2"
+        every { messages.channelWrapper.properties } returns ChannelProperties().apply {
+            channelSerial = "channel-serial-2"
+            attachSerial = "attach-serial-2"
+        }
         channelStateListenerSlot.captured.onChannelStateChanged(
             buildChannelStateChange(
                 current = ChannelState.attached,
@@ -205,8 +204,8 @@ class MessagesTest {
         assertEquals("attach-serial-2", subscription1.fromSerialProvider().await())
 
         // Check channelSerial is used at the point of subscription when state is attached
-        messages.channel.properties.channelSerial = "channel-serial-3"
-        messages.channel.state = ChannelState.attached
+        every { messages.channelWrapper.properties } returns ChannelProperties().apply { channelSerial = "channel-serial-3" }
+        every { messages.channelWrapper.state } returns ChannelState.attached
 
         val subscription2 = (messages.subscribe {}) as DefaultMessagesSubscription
         assertEquals("channel-serial-3", subscription2.fromSerialProvider().await())
@@ -217,26 +216,26 @@ class MessagesTest {
         val listener1 = mockk<Messages.Listener>(relaxed = true)
         val listener2 = mockk<Messages.Listener>(relaxed = true)
 
-        messages.subscribe(listener1)
+        val pubSubMessageListenerSlot = slot<PubSubMessageListener>()
 
-        messages.channel.channelMulticaster.onMessage(buildDummyPubSubMessage())
+        every { messages.channelWrapper.subscribe("chat.message", capture(pubSubMessageListenerSlot)) } returns mockk()
+
+        messages.subscribe(listener1)
+        val capturedSlots = mutableListOf(pubSubMessageListenerSlot.captured)
+
+        capturedSlots.forEach { it.onMessage(buildDummyPubSubMessage()) }
 
         verify(exactly = 1) { listener1.onEvent(any()) }
 
         messages.subscribe(listener2)
+        capturedSlots.add(pubSubMessageListenerSlot.captured)
 
-        messages.channel.channelMulticaster.onMessage(buildDummyPubSubMessage())
+        capturedSlots.forEach { it.onMessage(buildDummyPubSubMessage()) }
 
         verify(exactly = 2) { listener1.onEvent(any()) }
         verify(exactly = 1) { listener2.onEvent(any()) }
     }
 }
-
-private val Channel.channelMulticaster: ChannelBase.MessageListener
-    get() {
-        val eventListeners = getPrivateField<HashMap<*, *>>("eventListeners")
-        return eventListeners["chat.message"] as ChannelBase.MessageListener
-    }
 
 private fun buildDummyPubSubMessage() = PubSubMessage().apply {
     data = JsonObject().apply {

--- a/chat-android/src/test/java/com/ably/chat/OccupancyTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/OccupancyTest.kt
@@ -1,11 +1,12 @@
 package com.ably.chat
 
-import com.ably.chat.room.createMockChannel
 import com.ably.chat.room.createMockChatApi
+import com.ably.chat.room.createMockRealtimeChannel
 import com.ably.chat.room.createMockRealtimeClient
 import com.ably.chat.room.createMockRoom
 import com.google.gson.JsonObject
 import io.mockk.every
+import io.mockk.mockk
 import io.mockk.slot
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.test.runTest
@@ -21,11 +22,10 @@ class OccupancyTest {
 
     @Before
     fun setUp() {
-        val mockRealtimeChannel = realtimeClient.createMockChannel()
-        every { mockRealtimeChannel.subscribe(capture(pubSubMessageListenerSlot)) } returns Unit
-
-        every { realtimeClient.channels.get(any(), any()) } returns mockRealtimeChannel
-
+        val channel = createMockRealtimeChannel("room1::\$chat::\$chatMessages")
+        every { channel.subscribe(capture(pubSubMessageListenerSlot)) } returns mockk(relaxUnitFun = true)
+        val channels = realtimeClient.channels
+        every { channels.get("room1::\$chat::\$chatMessages", any()) } returns channel
         val mockChatApi = createMockChatApi(realtimeClient)
         val room = createMockRoom("room1", realtimeClient = realtimeClient, chatApi = mockChatApi)
         occupancy = DefaultOccupancy(room)

--- a/chat-android/src/test/java/com/ably/chat/RoomReactionsTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/RoomReactionsTest.kt
@@ -1,13 +1,11 @@
 package com.ably.chat
 
-import com.ably.chat.room.createMockChannel
 import com.ably.chat.room.createMockRealtimeClient
 import com.ably.chat.room.createMockRoom
 import com.google.gson.JsonObject
-import io.ably.lib.realtime.Channel
-import io.ably.lib.realtime.buildRealtimeChannel
 import io.ably.lib.types.MessageExtras
 import io.mockk.every
+import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
 import kotlinx.coroutines.CompletableDeferred
@@ -17,23 +15,12 @@ import org.junit.Before
 import org.junit.Test
 
 class RoomReactionsTest {
-    private lateinit var realtimeChannel: Channel
     private lateinit var roomReactions: DefaultRoomReactions
     private lateinit var room: DefaultRoom
 
     @Before
     fun setUp() {
         val realtimeClient = createMockRealtimeClient()
-        realtimeChannel = realtimeClient.createMockChannel("room1::\$chat::\$reactions")
-
-        every { realtimeClient.channels.get(any(), any()) } answers {
-            val channelName = firstArg<String>()
-            if (channelName == "room1::\$chat::\$reactions") {
-                realtimeChannel
-            } else {
-                buildRealtimeChannel(channelName)
-            }
-        }
         room = createMockRoom("room1", "client1", realtimeClient = realtimeClient)
         roomReactions = DefaultRoomReactions(room)
     }
@@ -58,7 +45,7 @@ class RoomReactionsTest {
     fun `should be able to subscribe to incoming reactions`() = runTest {
         val pubSubMessageListenerSlot = slot<PubSubMessageListener>()
 
-        every { realtimeChannel.subscribe("roomReaction", capture(pubSubMessageListenerSlot)) } returns Unit
+        every { roomReactions.channelWrapper.subscribe("roomReaction", capture(pubSubMessageListenerSlot)) } returns mockk(relaxed = true)
 
         val deferredValue = CompletableDeferred<Reaction>()
 
@@ -66,7 +53,7 @@ class RoomReactionsTest {
             deferredValue.complete(it)
         }
 
-        verify { realtimeChannel.subscribe("roomReaction", any()) }
+        verify { roomReactions.channelWrapper.subscribe("roomReaction", any()) }
 
         pubSubMessageListenerSlot.captured.onMessage(
             PubSubMessage().apply {

--- a/chat-android/src/test/java/com/ably/chat/TestUtils.kt
+++ b/chat-android/src/test/java/com/ably/chat/TestUtils.kt
@@ -1,5 +1,7 @@
 package com.ably.chat
 
+import com.ably.http.HttpMethod
+import com.ably.pubsub.RealtimeClient
 import com.google.gson.JsonElement
 import io.ably.lib.types.AsyncHttpPaginatedResponse
 import io.mockk.every
@@ -21,9 +23,9 @@ fun buildAsyncHttpPaginatedResponse(items: List<JsonElement>): AsyncHttpPaginate
 
 fun mockMessagesApiResponse(realtimeClientMock: RealtimeClient, response: List<JsonElement>, roomId: String = "roomId") {
     every {
-        realtimeClientMock.requestAsync("GET", "/chat/v2/rooms/$roomId/messages", any(), any(), any(), any())
+        realtimeClientMock.requestAsync("/chat/v2/rooms/$roomId/messages", any(), HttpMethod.Get, any(), any(), any())
     } answers {
-        val callback = lastArg<AsyncHttpPaginatedResponse.Callback>()
+        val callback = secondArg<AsyncHttpPaginatedResponse.Callback>()
         callback.onResponse(
             buildAsyncHttpPaginatedResponse(response),
         )
@@ -32,9 +34,9 @@ fun mockMessagesApiResponse(realtimeClientMock: RealtimeClient, response: List<J
 
 fun mockSendMessageApiResponse(realtimeClientMock: RealtimeClient, response: JsonElement, roomId: String = "roomId") {
     every {
-        realtimeClientMock.requestAsync("POST", "/chat/v2/rooms/$roomId/messages", any(), any(), any(), any())
+        realtimeClientMock.requestAsync("/chat/v2/rooms/$roomId/messages", any(), HttpMethod.Post, any(), any(), any())
     } answers {
-        val callback = lastArg<AsyncHttpPaginatedResponse.Callback>()
+        val callback = secondArg<AsyncHttpPaginatedResponse.Callback>()
         callback.onResponse(
             buildAsyncHttpPaginatedResponse(
                 listOf(response),
@@ -45,9 +47,9 @@ fun mockSendMessageApiResponse(realtimeClientMock: RealtimeClient, response: Jso
 
 fun mockOccupancyApiResponse(realtimeClientMock: RealtimeClient, response: JsonElement, roomId: String = "roomId") {
     every {
-        realtimeClientMock.requestAsync("GET", "/chat/v2/rooms/$roomId/occupancy", any(), any(), any(), any())
+        realtimeClientMock.requestAsync("/chat/v2/rooms/$roomId/occupancy", any(), HttpMethod.Get, any(), any(), any())
     } answers {
-        val callback = lastArg<AsyncHttpPaginatedResponse.Callback>()
+        val callback = secondArg<AsyncHttpPaginatedResponse.Callback>()
         callback.onResponse(
             buildAsyncHttpPaginatedResponse(
                 listOf(response),

--- a/chat-android/src/test/java/com/ably/chat/integration/EmbeddedServer.kt
+++ b/chat-android/src/test/java/com/ably/chat/integration/EmbeddedServer.kt
@@ -1,0 +1,54 @@
+package com.ably.chat.integration
+
+import fi.iki.elonen.NanoHTTPD
+import java.io.ByteArrayInputStream
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+
+data class Request(
+    val path: String,
+    val params: Map<String, String> = emptyMap(),
+    val headers: Map<String, String> = emptyMap(),
+)
+
+data class Response(
+    val mimeType: String,
+    val data: ByteArray,
+)
+
+fun json(json: String): Response = Response(
+    mimeType = "application/json",
+    data = json.toByteArray(),
+)
+
+fun interface RequestHandler {
+    fun handle(request: Request): Response
+}
+
+class EmbeddedServer(port: Int, private val requestHandler: RequestHandler? = null) : NanoHTTPD(port) {
+    private val _servedRequests = MutableSharedFlow<Request>(
+        extraBufferCapacity = 1,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST,
+    )
+
+    val servedRequests: Flow<Request> = _servedRequests
+
+    override fun serve(session: IHTTPSession): Response {
+        val request = Request(
+            path = session.uri,
+            params = session.parms,
+            headers = session.headers,
+        )
+        _servedRequests.tryEmit(request)
+        val response = requestHandler?.handle(request)
+        return response?.toNanoHttp() ?: newFixedLengthResponse("<!DOCTYPE html><title>404</title>")
+    }
+}
+
+private fun Response.toNanoHttp(): NanoHTTPD.Response = NanoHTTPD.newFixedLengthResponse(
+    NanoHTTPD.Response.Status.OK,
+    mimeType,
+    ByteArrayInputStream(data),
+    data.size.toLong(),
+)

--- a/chat-android/src/test/java/com/ably/chat/integration/MessagesIntegrationTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/integration/MessagesIntegrationTest.kt
@@ -1,11 +1,13 @@
 package com.ably.chat.integration
 
+import com.ably.chat.BuildConfig
 import com.ably.chat.Message
 import com.ably.chat.MessageEvent
 import com.ably.chat.MessageMetadata
 import com.ably.chat.RoomOptions
 import com.ably.chat.RoomStatus
 import com.ably.chat.assertWaiter
+import io.ably.lib.realtime.channelOptions
 import io.ably.lib.types.MessageAction
 import java.util.UUID
 import kotlinx.coroutines.CompletableDeferred
@@ -246,6 +248,17 @@ class MessagesIntegrationTest {
         assertEquals(deletedMessage.clientId, receivedMsg2.clientId)
         assertEquals(deletedMessage.roomId, receivedMsg2.roomId)
         assertEquals(deletedMessage.action, receivedMsg2.action)
+    }
+
+    @Test
+    fun `messages channel should include agent channel param`() = runTest {
+        val chatClient = sandbox.createSandboxChatClient()
+        val roomId = UUID.randomUUID().toString()
+        val room = chatClient.rooms.get(roomId)
+        assertEquals(
+            "chat-kotlin/${BuildConfig.APP_VERSION}",
+            room.messages.channel.channelOptions?.params?.get("agent"),
+        )
     }
 
     companion object {

--- a/chat-android/src/test/java/com/ably/chat/integration/RequestHeaderTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/integration/RequestHeaderTest.kt
@@ -1,0 +1,70 @@
+package com.ably.chat.integration
+
+import app.cash.turbine.test
+import com.ably.chat.ChatClient
+import com.ably.chat.assertWaiter
+import fi.iki.elonen.NanoHTTPD
+import io.ably.lib.realtime.AblyRealtime
+import io.ably.lib.types.ClientOptions
+import java.util.UUID
+import kotlinx.coroutines.test.runTest
+import org.junit.AfterClass
+import org.junit.Assert
+import org.junit.BeforeClass
+import org.junit.Test
+
+class RequestHeaderTest {
+
+    @Test
+    fun `should use additional agents in Realtime wrapper SDK client calls`() = runTest {
+        val ablyRealtime = createAblyRealtime()
+        val chatClient = ChatClient(ablyRealtime)
+        val roomId = UUID.randomUUID().toString()
+
+        server.servedRequests.test {
+            chatClient.rooms.get(roomId).messages.get()
+            val agents = awaitItem().headers["ably-agent"]?.split(" ") ?: setOf()
+            Assert.assertTrue(
+                agents.contains("chat-kotlin/${com.ably.chat.BuildConfig.APP_VERSION}"),
+            )
+        }
+    }
+
+    companion object {
+
+        const val PORT = 27_332
+        lateinit var server: EmbeddedServer
+
+        @JvmStatic
+        @BeforeClass
+        fun setUp() = runTest {
+            server = EmbeddedServer(PORT) {
+                when (it.path) {
+                    "/time" -> json("[1739551931167]")
+                    else -> json("[]")
+                }
+            }
+            server.start(NanoHTTPD.SOCKET_READ_TIMEOUT, true)
+            assertWaiter { server.wasStarted() }
+        }
+
+        @JvmStatic
+        @AfterClass
+        fun tearDown() {
+            server.stop()
+        }
+    }
+}
+
+private fun createAblyRealtime(): AblyRealtime {
+    val options = ClientOptions("xxxxx:yyyyyyy").apply {
+        port = RequestHeaderTest.PORT
+        useBinaryProtocol = false
+        realtimeHost = "localhost"
+        restHost = "localhost"
+        tls = false
+        autoConnect = false
+    }
+
+    return AblyRealtime(options)
+}

--- a/chat-android/src/test/java/com/ably/chat/room/RoomFeatureSharedChannelTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/room/RoomFeatureSharedChannelTest.kt
@@ -1,6 +1,5 @@
 package com.ably.chat.room
 
-import io.ably.lib.realtime.buildRealtimeChannel
 import io.ably.lib.types.ChannelMode
 import io.ably.lib.types.ChannelOptions
 import io.mockk.every
@@ -19,12 +18,13 @@ class RoomFeatureSharedChannelTest {
     fun `(CHA-RC3a, CHA-RC2f) Features with shared channel should call channels#get only once with combined modes+options`() = runTest {
         val mockRealtimeClient = createMockRealtimeClient()
         val capturedChannelOptions = mutableListOf<ChannelOptions>()
+        val channels = mockRealtimeClient.channels
 
         every {
-            mockRealtimeClient.channels.get("1234::\$chat::\$chatMessages", any<ChannelOptions>())
+            channels.get("1234::\$chat::\$chatMessages", any<ChannelOptions>())
         } answers {
             capturedChannelOptions.add(secondArg())
-            buildRealtimeChannel()
+            createMockRealtimeChannel("1234::\$chat::\$chatMessages")
         }
 
         // Create room with all feature enabled,
@@ -51,19 +51,19 @@ class RoomFeatureSharedChannelTest {
 
         // channels.get is called only once for Messages, occupancy and presence since they share the same channel
         verify(exactly = 1) {
-            mockRealtimeClient.channels.get("1234::\$chat::\$chatMessages", any<ChannelOptions>())
+            channels.get("1234::\$chat::\$chatMessages", any<ChannelOptions>())
         }
         // channels.get called separately for typing since it uses it's own channel
         verify(exactly = 1) {
-            mockRealtimeClient.channels.get("1234::\$chat::\$typingIndicators", any<ChannelOptions>())
+            channels.get("1234::\$chat::\$typingIndicators", any<ChannelOptions>())
         }
         // channels.get called separately for reactions since it uses it's own channel
         verify(exactly = 1) {
-            mockRealtimeClient.channels.get("1234::\$chat::\$reactions", any<ChannelOptions>())
+            channels.get("1234::\$chat::\$reactions", any<ChannelOptions>())
         }
         // channels.get is called thrice for all features
         verify(exactly = 3) {
-            mockRealtimeClient.channels.get(any<String>(), any<ChannelOptions>())
+            channels.get(any<String>(), any<ChannelOptions>())
         }
     }
 }

--- a/chat-android/src/test/java/io/ably/lib/realtime/RealtimeUtils.kt
+++ b/chat-android/src/test/java/io/ably/lib/realtime/RealtimeUtils.kt
@@ -1,6 +1,7 @@
 package io.ably.lib.realtime
 
 import io.ably.lib.realtime.ChannelStateListener.ChannelStateChange
+import io.ably.lib.types.ChannelOptions
 import io.ably.lib.types.ClientOptions
 import io.ably.lib.types.ErrorInfo
 
@@ -37,3 +38,6 @@ fun buildRealtimeConnection() = AblyRealtime(
         autoConnect = false
     },
 ).connection
+
+val ChannelBase.channelOptions: ChannelOptions?
+    get() = options

--- a/example/src/main/java/com/ably/chat/example/MainActivity.kt
+++ b/example/src/main/java/com/ably/chat/example/MainActivity.kt
@@ -44,12 +44,12 @@ import androidx.compose.ui.unit.dp
 import com.ably.chat.ChatClient
 import com.ably.chat.Message
 import com.ably.chat.MessageMetadata
-import com.ably.chat.RealtimeClient
 import com.ably.chat.Room
 import com.ably.chat.RoomOptions
 import com.ably.chat.Typing
 import com.ably.chat.example.ui.PresencePopup
 import com.ably.chat.example.ui.theme.AblyChatExampleTheme
+import io.ably.lib.realtime.AblyRealtime
 import io.ably.lib.types.ClientOptions
 import io.ably.lib.types.MessageAction
 import java.util.UUID
@@ -62,7 +62,7 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        val realtimeClient = RealtimeClient(
+        val realtimeClient = AblyRealtime(
             ClientOptions().apply {
                 key = BuildConfig.ABLY_KEY
                 clientId = randomClientId

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,6 +19,8 @@ mockk = "1.13.13"
 coroutine = "1.9.0"
 build-config = "5.5.1"
 ktor = "3.0.1"
+nanohttpd = "2.3.0"
+turbine = "1.2.0"
 
 [libraries]
 junit = { group = "junit", name = "junit", version.ref = "junit" }
@@ -51,6 +53,9 @@ coroutine-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-t
 
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
+
+nanohttpd = { group = "org.nanohttpd", name = "nanohttpd", version.ref = "nanohttpd" }
+turbine = { group = "app.cash.turbine", name = "turbine", version.ref = "turbine" }
 
 [bundles]
 ktor-client = ["ktor-client-core", "ktor-client-cio"]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,6 +24,7 @@ ktor = "3.0.1"
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 detekt-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detekt" }
 ably-android = { module = "io.ably:ably-android", version.ref = "ably" }
+ably-pubsub-adapter = { module = "io.ably:pubsub-adapter", version.ref = "ably" }
 androidx-test-core = { module = "androidx.test:core", version.ref = "androidx-test" }
 androidx-test-runner = { module = "androidx.test:runner", version.ref = "androidx-test" }
 androidx-junit = { module = "androidx.test.ext:junit", version.ref = "androidx-junit" }


### PR DESCRIPTION
To track Chat SDK usage, we replaced the old ably-java interfaces for Channel, Client, and Presence with new Kotlin-based interfaces. The new Kotlin interfaces include the `createWrapperSDKProxy` method, which injects agent information for the new set of agents.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Integrated additional libraries for enhanced real-time functionality and testing capabilities.
	- Added a new embedded server for testing HTTP interactions.
- **Refactor**
	- Improved type safety by replacing string-based HTTP methods with enumerated types.
	- Unified channel handling across messaging, occupancy, presence, reactions, and typing to enhance encapsulation.
- **Tests**
	- Updated testing frameworks and mocks to support the refactored channel and API modifications.
	- Added new integration tests to verify channel parameters and request headers.
- **Chores**
	- Refined build and dependency configurations to support the new integrations and improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->