### PR TITLE
[ECO-5226] fix: add filtering to the occupancy subscription

### DIFF
--- a/chat-android/src/main/java/com/ably/chat/Occupancy.kt
+++ b/chat-android/src/main/java/com/ably/chat/Occupancy.kt
@@ -72,6 +72,8 @@ data class OccupancyEvent(
     val presenceMembers: Int,
 )
 
+const val META_OCCUPANCY_EVENT_NAME = "[meta]occupancy"
+
 internal class DefaultOccupancy(
     private val room: DefaultRoom,
 ) : Occupancy, ContributesToRoomLifecycleImpl(room.logger) {
@@ -111,7 +113,7 @@ internal class DefaultOccupancy(
             internalChannelListener(it)
         }
 
-        occupancySubscription = channelWrapper.subscribe(occupancyListener).asChatSubscription()
+        occupancySubscription = channelWrapper.subscribe(META_OCCUPANCY_EVENT_NAME, occupancyListener).asChatSubscription()
     }
 
     // (CHA-O4)

--- a/chat-android/src/test/java/com/ably/chat/OccupancyTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/OccupancyTest.kt
@@ -8,6 +8,7 @@ import com.google.gson.JsonObject
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
+import io.mockk.verify
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -16,19 +17,19 @@ import org.junit.Test
 
 class OccupancyTest {
 
-    private lateinit var occupancy: Occupancy
+    private lateinit var occupancy: DefaultOccupancy
     private val pubSubMessageListenerSlot = slot<PubSubMessageListener>()
     private val realtimeClient = createMockRealtimeClient()
 
     @Before
     fun setUp() {
         val channel = createMockRealtimeChannel("room1::\$chat::\$chatMessages")
-        every { channel.subscribe(capture(pubSubMessageListenerSlot)) } returns mockk(relaxUnitFun = true)
+        every { channel.subscribe(any<String>(), capture(pubSubMessageListenerSlot)) } returns mockk(relaxUnitFun = true)
         val channels = realtimeClient.channels
         every { channels.get("room1::\$chat::\$chatMessages", any()) } returns channel
         val mockChatApi = createMockChatApi(realtimeClient)
         val room = createMockRoom("room1", realtimeClient = realtimeClient, chatApi = mockChatApi)
-        occupancy = DefaultOccupancy(room)
+        occupancy = room.occupancy as DefaultOccupancy
     }
 
     /**
@@ -142,5 +143,12 @@ class OccupancyTest {
         pubSubMessageListenerSlot.captured.onMessage(fakeMessage)
 
         assertEquals(OccupancyEvent(connections = 1, presenceMembers = 1), deferredEvent.await())
+    }
+
+    @Test
+    fun `should filter occupancy messages by event name`() = runTest {
+        verify(exactly = 1) {
+            occupancy.channelWrapper.subscribe("[meta]occupancy", any())
+        }
     }
 }


### PR DESCRIPTION
To avoid errors in logs add filtration for occupancy events

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced chat occupancy event handling by updating the subscription logic to use a specific event identifier for improved clarity and consistency.
- **Tests**
	- Added a test case to verify that occupancy messages are accurately filtered, ensuring reliable behavior in occupancy tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->