### PR TITLE
[ECO-5231] Renamed ClientOptions to ChatClientOptions

### DIFF
--- a/chat-android/src/main/java/com/ably/chat/ChatClient.kt
+++ b/chat-android/src/main/java/com/ably/chat/ChatClient.kt
@@ -31,17 +31,17 @@ interface ChatClient {
     val realtime: AblyRealtime
 
     /**
-     * The resolved client options for the client, including any defaults that have been set.
+     * The chat client options for the client, including any defaults that have been set.
      */
-    val clientOptions: ClientOptions
+    val clientOptions: ChatClientOptions
 }
 
-fun ChatClient(realtimeClient: AblyRealtime, clientOptions: ClientOptions = ClientOptions()): ChatClient =
+fun ChatClient(realtimeClient: AblyRealtime, clientOptions: ChatClientOptions = ChatClientOptions()): ChatClient =
     DefaultChatClient(realtimeClient, clientOptions)
 
 internal class DefaultChatClient(
     override val realtime: AblyRealtime,
-    override val clientOptions: ClientOptions,
+    override val clientOptions: ChatClientOptions,
 ) : ChatClient {
 
     private val realtimeClientWrapper = RealtimeClient(realtime).createWrapperSdkProxy(

--- a/chat-android/src/main/java/com/ably/chat/ChatClientOptions.kt
+++ b/chat-android/src/main/java/com/ably/chat/ChatClientOptions.kt
@@ -3,7 +3,7 @@ package com.ably.chat
 /**
  * Configuration options for the chat client.
  */
-data class ClientOptions(
+data class ChatClientOptions(
     /**
      * A custom log handler that will be used to log messages from the client.
      * @defaultValue The client will log messages to the console.

--- a/chat-android/src/main/java/com/ably/chat/Rooms.kt
+++ b/chat-android/src/main/java/com/ably/chat/Rooms.kt
@@ -13,10 +13,10 @@ import kotlinx.coroutines.launch
  */
 interface Rooms {
     /**
-     * Get the client options used to create the Chat instance.
-     * @returns ClientOptions
+     * Get the chat client options used to create the Chat instance.
+     * @returns ChatClientOptions
      */
-    val clientOptions: ClientOptions
+    val clientOptions: ChatClientOptions
 
     /**
      * Gets a room reference by ID. The Rooms class ensures that only one reference
@@ -61,7 +61,7 @@ interface Rooms {
 internal class DefaultRooms(
     private val realtimeClient: RealtimeClient,
     private val chatApi: ChatApi,
-    override val clientOptions: ClientOptions,
+    override val clientOptions: ChatClientOptions,
     private val clientId: String,
     logger: Logger,
 ) : Rooms {

--- a/chat-android/src/test/java/com/ably/chat/integration/Sandbox.kt
+++ b/chat-android/src/test/java/com/ably/chat/integration/Sandbox.kt
@@ -1,6 +1,6 @@
 package com.ably.chat.integration
 
-import com.ably.chat.ClientOptions
+import com.ably.chat.ChatClientOptions
 import com.ably.chat.DefaultChatClient
 import com.ably.chat.serverError
 import com.google.gson.JsonElement
@@ -59,7 +59,7 @@ class Sandbox private constructor(val appId: String, val apiKey: String) {
 
 internal fun Sandbox.createSandboxChatClient(chatClientId: String = "sandbox-client"): DefaultChatClient {
     val realtime = createSandboxRealtime(chatClientId)
-    return DefaultChatClient(realtime, ClientOptions())
+    return DefaultChatClient(realtime, ChatClientOptions())
 }
 
 internal fun Sandbox.createSandboxRealtime(chatClientId: String): AblyRealtime =
@@ -74,7 +74,7 @@ internal fun Sandbox.createSandboxRealtime(chatClientId: String): AblyRealtime =
 internal suspend fun Sandbox.getConnectedChatClient(chatClientId: String = "sandbox-client"): DefaultChatClient {
     val realtime = createSandboxRealtime(chatClientId)
     realtime.ensureConnected()
-    return DefaultChatClient(realtime, ClientOptions())
+    return DefaultChatClient(realtime, ChatClientOptions())
 }
 
 private suspend fun AblyRealtime.ensureConnected() {

--- a/chat-android/src/test/java/com/ably/chat/room/RoomGetTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/room/RoomGetTest.kt
@@ -1,7 +1,7 @@
 package com.ably.chat.room
 
 import com.ably.chat.ChatApi
-import com.ably.chat.ClientOptions
+import com.ably.chat.ChatClientOptions
 import com.ably.chat.DefaultRoom
 import com.ably.chat.DefaultRooms
 import com.ably.chat.PresenceOptions
@@ -36,7 +36,7 @@ class RoomGetTest {
     fun `(CHA-RC1f) Requesting a room from the Chat Client return instance of a room with the provided id and options`() = runTest {
         val mockRealtimeClient = createMockRealtimeClient()
         val chatApi = mockk<ChatApi>(relaxed = true)
-        val rooms = DefaultRooms(mockRealtimeClient, chatApi, ClientOptions(), clientId, logger)
+        val rooms = DefaultRooms(mockRealtimeClient, chatApi, ChatClientOptions(), clientId, logger)
         val room = rooms.get("1234", RoomOptions())
         Assert.assertNotNull(room)
         Assert.assertEquals("1234", room.roomId)
@@ -48,7 +48,7 @@ class RoomGetTest {
     fun `(CHA-RC1f1) If the room id already exists, and newly requested with different options, then ErrorInfo with code 40000 is thrown`() = runTest {
         val mockRealtimeClient = createMockRealtimeClient()
         val chatApi = mockk<ChatApi>(relaxed = true)
-        val rooms = spyk(DefaultRooms(mockRealtimeClient, chatApi, ClientOptions(), clientId, logger), recordPrivateCalls = true)
+        val rooms = spyk(DefaultRooms(mockRealtimeClient, chatApi, ChatClientOptions(), clientId, logger), recordPrivateCalls = true)
 
         // Create room with id "1234"
         val room = rooms.get("1234", RoomOptions())
@@ -70,7 +70,7 @@ class RoomGetTest {
     fun `(CHA-RC1f2) If the room id already exists, and newly requested with same options, then returns same room`() = runTest {
         val mockRealtimeClient = createMockRealtimeClient()
         val chatApi = mockk<ChatApi>(relaxed = true)
-        val rooms = spyk(DefaultRooms(mockRealtimeClient, chatApi, ClientOptions(), clientId, logger), recordPrivateCalls = true)
+        val rooms = spyk(DefaultRooms(mockRealtimeClient, chatApi, ChatClientOptions(), clientId, logger), recordPrivateCalls = true)
 
         val room1 = rooms.get("1234", RoomOptions())
         Assert.assertEquals(1, rooms.RoomIdToRoom.size)
@@ -120,7 +120,7 @@ class RoomGetTest {
     fun `(CHA-RC1f3) If no CHA-RC1g release operation is in progress, a new room instance shall be created, and added to the room map`() = runTest {
         val mockRealtimeClient = createMockRealtimeClient()
         val chatApi = mockk<ChatApi>(relaxed = true)
-        val rooms = spyk(DefaultRooms(mockRealtimeClient, chatApi, ClientOptions(), clientId, logger), recordPrivateCalls = true)
+        val rooms = spyk(DefaultRooms(mockRealtimeClient, chatApi, ChatClientOptions(), clientId, logger), recordPrivateCalls = true)
         val roomId = "1234"
 
         // No release op. in progress
@@ -140,7 +140,7 @@ class RoomGetTest {
         val roomId = "1234"
         val mockRealtimeClient = createMockRealtimeClient()
         val chatApi = mockk<ChatApi>(relaxed = true)
-        val rooms = spyk(DefaultRooms(mockRealtimeClient, chatApi, ClientOptions(), clientId, logger), recordPrivateCalls = true)
+        val rooms = spyk(DefaultRooms(mockRealtimeClient, chatApi, ChatClientOptions(), clientId, logger), recordPrivateCalls = true)
 
         val defaultRoom = spyk(
             DefaultRoom(roomId, RoomOptions.default, mockRealtimeClient, chatApi, clientId, logger),

--- a/chat-android/src/test/java/com/ably/chat/room/RoomReleaseTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/room/RoomReleaseTest.kt
@@ -1,7 +1,7 @@
 package com.ably.chat.room
 
 import com.ably.chat.ChatApi
-import com.ably.chat.ClientOptions
+import com.ably.chat.ChatClientOptions
 import com.ably.chat.DefaultRoom
 import com.ably.chat.DefaultRooms
 import com.ably.chat.ErrorCode
@@ -43,7 +43,7 @@ class RoomReleaseTest {
         val roomId = "1234"
         val mockRealtimeClient = createMockRealtimeClient()
         val chatApi = mockk<ChatApi>(relaxed = true)
-        val rooms = spyk(DefaultRooms(mockRealtimeClient, chatApi, ClientOptions(), clientId, logger), recordPrivateCalls = true)
+        val rooms = spyk(DefaultRooms(mockRealtimeClient, chatApi, ChatClientOptions(), clientId, logger), recordPrivateCalls = true)
 
         val defaultRoom = spyk(
             DefaultRoom(roomId, RoomOptions.default, mockRealtimeClient, chatApi, clientId, logger),
@@ -69,7 +69,7 @@ class RoomReleaseTest {
         val roomId = "1234"
         val mockRealtimeClient = createMockRealtimeClient()
         val chatApi = mockk<ChatApi>(relaxed = true)
-        val rooms = spyk(DefaultRooms(mockRealtimeClient, chatApi, ClientOptions(), clientId, logger), recordPrivateCalls = true)
+        val rooms = spyk(DefaultRooms(mockRealtimeClient, chatApi, ChatClientOptions(), clientId, logger), recordPrivateCalls = true)
 
         val defaultRoom = spyk(
             DefaultRoom(roomId, RoomOptions.default, mockRealtimeClient, chatApi, clientId, logger),
@@ -111,7 +111,7 @@ class RoomReleaseTest {
         val roomId = "1234"
         val mockRealtimeClient = createMockRealtimeClient()
         val chatApi = mockk<ChatApi>(relaxed = true)
-        val rooms = spyk(DefaultRooms(mockRealtimeClient, chatApi, ClientOptions(), clientId, logger), recordPrivateCalls = true)
+        val rooms = spyk(DefaultRooms(mockRealtimeClient, chatApi, ChatClientOptions(), clientId, logger), recordPrivateCalls = true)
 
         // No room exists
         Assert.assertEquals(0, rooms.RoomIdToRoom.size)
@@ -131,7 +131,7 @@ class RoomReleaseTest {
         val roomId = "1234"
         val mockRealtimeClient = createMockRealtimeClient()
         val chatApi = mockk<ChatApi>(relaxed = true)
-        val rooms = spyk(DefaultRooms(mockRealtimeClient, chatApi, ClientOptions(), clientId, logger), recordPrivateCalls = true)
+        val rooms = spyk(DefaultRooms(mockRealtimeClient, chatApi, ChatClientOptions(), clientId, logger), recordPrivateCalls = true)
 
         val defaultRoom = spyk(
             DefaultRoom(roomId, RoomOptions.default, mockRealtimeClient, chatApi, clientId, logger),
@@ -188,7 +188,7 @@ class RoomReleaseTest {
         val roomId = "1234"
         val mockRealtimeClient = createMockRealtimeClient()
         val chatApi = mockk<ChatApi>(relaxed = true)
-        val rooms = spyk(DefaultRooms(mockRealtimeClient, chatApi, ClientOptions(), clientId, logger), recordPrivateCalls = true)
+        val rooms = spyk(DefaultRooms(mockRealtimeClient, chatApi, ChatClientOptions(), clientId, logger), recordPrivateCalls = true)
 
         val defaultRoom = spyk(
             DefaultRoom(roomId, RoomOptions.default, mockRealtimeClient, chatApi, clientId, logger),


### PR DESCRIPTION
- Renamed to avoid import conflicts.
- Fixed #112 
- Link to discussion => https://ably-real-time.slack.com/archives/C03JDBVM5MY/p1740659985753339?thread_ts=1740138316.281729&cid=C03JDBVM5MY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated configuration settings for chat functionalities to utilize a more specific options type, enhancing clarity and consistency.
- **Tests**
  - Modified chat and room tests to incorporate the new options type, ensuring alignment with the updated configuration and maintaining test reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->