### PR TITLE
[ECO-5242][CHADR-093] Implement ephemeral typing

### DIFF
--- a/chat-android/src/main/java/com/ably/chat/EventTypes.kt
+++ b/chat-android/src/main/java/com/ably/chat/EventTypes.kt
@@ -73,9 +73,19 @@ public enum class PresenceEventType(public val eventName: String) {
     Present("present"),
 }
 
+/**
+ * Enum representing typing events.
+ */
 public enum class TypingEventType(public val eventName: String) {
-    /** The set of currently typing users has changed. */
-    Changed("typing.changed"),
+    /**
+     * Event triggered when a user starts typing.
+     */
+    Started("typing.started"),
+
+    /**
+     * Event triggered when a user stops typing.
+     */
+    Stopped("typing.stopped"),
 }
 
 /**

--- a/chat-android/src/main/java/com/ably/chat/RoomOptions.kt
+++ b/chat-android/src/main/java/com/ably/chat/RoomOptions.kt
@@ -3,6 +3,8 @@ package com.ably.chat
 import com.ably.chat.annotations.ChatDsl
 import io.ably.lib.types.ChannelMode
 import io.ably.lib.types.ChannelOptions
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 
 /**
  * Represents the options for a given chat room.
@@ -73,8 +75,9 @@ public interface PresenceOptions {
 public interface TypingOptions {
     /**
      * The throttle for typing events in milliseconds. This is the minimum time between typing events being sent.
+     * @defaultValue 10 seconds
      */
-    public val heartbeatThrottleMs: Long
+    public val heartbeatThrottle: Duration
 }
 
 /**
@@ -109,7 +112,7 @@ public class MutablePresenceOptions : PresenceOptions {
 
 @ChatDsl
 public class MutableTypingOptions : TypingOptions {
-    override var heartbeatThrottleMs: Long = 10_000
+    override var heartbeatThrottle: Duration = 10.seconds
 }
 
 @ChatDsl
@@ -150,7 +153,7 @@ internal data class EquatablePresenceOptions(
 ) : PresenceOptions
 
 internal data class EquatableTypingOptions(
-    override val heartbeatThrottleMs: Long,
+    override val heartbeatThrottle: Duration,
 ) : TypingOptions
 
 internal data object EquatableRoomReactionsOptions : RoomReactionsOptions
@@ -169,7 +172,7 @@ internal fun MutablePresenceOptions.asEquatable() = EquatablePresenceOptions(
 )
 
 internal fun MutableTypingOptions.asEquatable() = EquatableTypingOptions(
-    heartbeatThrottleMs = heartbeatThrottleMs,
+    heartbeatThrottle = heartbeatThrottle,
 )
 
 /**
@@ -178,9 +181,9 @@ internal fun MutableTypingOptions.asEquatable() = EquatableTypingOptions(
  */
 internal fun RoomOptions.validateRoomOptions(logger: Logger) {
     typing?.let {
-        if (it.heartbeatThrottleMs <= 0) {
-            logger.error("Typing heartbeatThrottleMs must be greater than 0, found ${it.heartbeatThrottleMs}")
-            throw ablyException("Typing heartbeatThrottleMs must be greater than 0", ErrorCode.InvalidRequestBody)
+        if (it.heartbeatThrottle.inWholeMilliseconds <= 0) {
+            logger.error("Typing heartbeatThrottle must be greater than 0, found ${it.heartbeatThrottle}")
+            throw ablyException("Typing heartbeatThrottle must be greater than 0", ErrorCode.InvalidRequestBody)
         }
     }
 }

--- a/chat-android/src/main/java/com/ably/chat/RoomOptions.kt
+++ b/chat-android/src/main/java/com/ably/chat/RoomOptions.kt
@@ -70,12 +70,11 @@ public data class PresenceOptions(
  * Represents the typing options for a chat room.
  */
 public data class TypingOptions(
+
     /**
-     * The timeout for typing events in milliseconds. If typing.start() is not called for this amount of time, a stop
-     * typing event will be fired, resulting in the user being removed from the currently typing set.
-     * @defaultValue 5000
+     * The throttle for typing events in milliseconds. This is the minimum time between typing events being sent.
      */
-    val timeoutMs: Long = 5000,
+    val heartbeatThrottleMs: Long = 10_000,
 )
 
 /**
@@ -106,9 +105,9 @@ public class OccupancyOptions {
  */
 internal fun RoomOptions.validateRoomOptions(logger: Logger) {
     typing?.let {
-        if (typing.timeoutMs <= 0) {
-            logger.error("Typing timeout must be greater than 0, found ${typing.timeoutMs}")
-            throw ablyException("Typing timeout must be greater than 0", ErrorCode.InvalidRequestBody)
+        if (typing.heartbeatThrottleMs <= 0) {
+            logger.error("Typing heartbeatThrottleMs must be greater than 0, found ${typing.heartbeatThrottleMs}")
+            throw ablyException("Typing heartbeatThrottleMs must be greater than 0", ErrorCode.InvalidRequestBody)
         }
     }
 }

--- a/chat-android/src/main/java/com/ably/chat/Typing.kt
+++ b/chat-android/src/main/java/com/ably/chat/Typing.kt
@@ -99,7 +99,29 @@ public fun Typing.asFlow(): Flow<TypingEvent> = transformCallbackAsFlow {
 /**
  * Represents a typing event.
  */
-public data class TypingEvent(val currentlyTyping: Set<String>)
+public data class TypingEvent(
+    /**
+     * The set of user clientIds that are currently typing.
+     */
+    val currentlyTyping: Set<String>,
+
+    /**
+     * The change that caused this event.
+     */
+    val change: TypingChange,
+) {
+    public data class TypingChange(
+        /**
+         * The client ID of the user who started or stopped typing.
+         */
+        val clientId: String,
+
+        /**
+         * The type of typing event.
+         */
+        val type: TypingEventType,
+    )
+}
 
 internal class DefaultTyping(
     private val room: DefaultRoom,

--- a/chat-android/src/test/java/com/ably/chat/RoomOptionTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/RoomOptionTest.kt
@@ -1,5 +1,6 @@
 package com.ably.chat
 
+import kotlin.time.Duration.Companion.milliseconds
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
@@ -17,7 +18,10 @@ class RoomOptionTest {
 
     @Test
     fun `custom typing options should be equal`() {
-        assertEquals(buildRoomOptions { typing { heartbeatThrottleMs = 10 } }, buildRoomOptions { typing { heartbeatThrottleMs = 10 } })
+        assertEquals(
+            buildRoomOptions { typing { heartbeatThrottle = 10.milliseconds } },
+            buildRoomOptions { typing { heartbeatThrottle = 10.milliseconds } },
+        )
     }
 
     @Test

--- a/chat-android/src/test/java/com/ably/chat/TestUtils.kt
+++ b/chat-android/src/test/java/com/ably/chat/TestUtils.kt
@@ -116,3 +116,10 @@ suspend fun <T>Any.invokePrivateSuspendMethod(methodName: String, vararg args: A
         it.invoke(this, *args, cont)
     }
 }
+
+fun <T> Any.invokePrivateMethod(methodName: String, vararg args: Any?): T {
+    val method = javaClass.declaredMethods.find { it.name == methodName }
+    method?.isAccessible = true
+    @Suppress("UNCHECKED_CAST")
+    return method?.invoke(this, *args) as T
+}

--- a/chat-android/src/test/java/com/ably/chat/TypingTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/TypingTest.kt
@@ -61,7 +61,7 @@ class TypingTest {
             publishedMessage = firstArg()
             secondArg<CompletionListener>().onSuccess()
         }
-        typing.start()
+        typing.keyStroke()
         verify(exactly = 1) { typingChannel.publish(any<Message>(), any()) }
         assertEquals(TypingEventType.Started.eventName, publishedMessage?.name)
         assertEquals(DEFAULT_CLIENT_ID, publishedMessage?.data)
@@ -84,12 +84,12 @@ class TypingTest {
 
         scope.launch {
             repeat(5) {
-                typing.start()
+                typing.keyStroke()
             }
         }
         testScheduler.runCurrent()
 
-        coVerify(exactly = 5) { typing.start() }
+        coVerify(exactly = 5) { typing.keyStroke() }
 
         verify(exactly = 1) { typingChannel.publish(any<Message>(), any()) }
         assertEquals(TypingEventType.Started.eventName, publishedMessage?.name)
@@ -102,12 +102,12 @@ class TypingTest {
         // Only one message should be published, since 10 second heartbeatThrottleMs is passed
         scope.launch {
             repeat(5) {
-                typing.start()
+                typing.keyStroke()
             }
         }
         testScheduler.runCurrent()
 
-        coVerify(exactly = 10) { typing.start() }
+        coVerify(exactly = 10) { typing.keyStroke() }
 
         verify(exactly = 2) { typingChannel.publish(any<Message>(), any()) }
         assertEquals(TypingEventType.Started.eventName, publishedMessage?.name)
@@ -164,12 +164,12 @@ class TypingTest {
         }
 
         scope.launch {
-            typing.start()
+            typing.keyStroke()
         }
 
         testScheduler.runCurrent()
 
-        coVerify(exactly = 1) { typing.start() }
+        coVerify(exactly = 1) { typing.keyStroke() }
 
         verify(exactly = 1) { typingChannel.publish(any<Message>(), any()) }
         assertEquals(TypingEventType.Started.eventName, publishedMessage?.name)

--- a/chat-android/src/test/java/com/ably/chat/TypingTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/TypingTest.kt
@@ -32,10 +32,6 @@ class TypingTest {
     @Before
     fun setUp() {
         val realtimeClient = createMockRealtimeClient()
-        every { typingChannel.publish(any(), DEFAULT_CLIENT_ID, any()) } answers {
-            val completionListener = arg<CompletionListener>(2)
-            completionListener.onSuccess()
-        }
 
         val channels = realtimeClient.channels
         every { channels.get(any(), any()) } returns typingChannel
@@ -62,7 +58,6 @@ class TypingTest {
         typing.keystroke()
         verify(exactly = 1) { typingChannel.publish(any<Message>(), any()) }
         assertEquals(TypingEventType.Started.eventName, publishedMessage?.name)
-        assertEquals(DEFAULT_CLIENT_ID, publishedMessage?.data)
     }
 
     /**
@@ -88,7 +83,6 @@ class TypingTest {
 
         verify(exactly = 1) { typingChannel.publish(any<Message>(), any()) }
         assertEquals(TypingEventType.Started.eventName, publishedMessage?.name)
-        assertEquals(DEFAULT_CLIENT_ID, publishedMessage?.data)
 
         // Advance heartbeatThrottle by 10 seconds
         typing.setPrivateField("typingHeartbeatStarted", currentTime - 10.seconds)
@@ -100,7 +94,6 @@ class TypingTest {
 
         verify(exactly = 2) { typingChannel.publish(any<Message>(), any()) }
         assertEquals(TypingEventType.Started.eventName, publishedMessage?.name)
-        assertEquals(DEFAULT_CLIENT_ID, publishedMessage?.data)
     }
 
     /**
@@ -153,13 +146,11 @@ class TypingTest {
 
         verify(exactly = 1) { typingChannel.publish(any<Message>(), any()) }
         assertEquals(TypingEventType.Started.eventName, publishedMessage?.name)
-        assertEquals(DEFAULT_CLIENT_ID, publishedMessage?.data)
 
         typing.stop()
 
         verify(exactly = 2) { typingChannel.publish(any<Message>(), any()) }
         assertEquals(TypingEventType.Stopped.eventName, publishedMessage?.name)
-        assertEquals(DEFAULT_CLIENT_ID, publishedMessage?.data)
     }
 
     @Test

--- a/chat-android/src/test/java/com/ably/chat/TypingTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/TypingTest.kt
@@ -71,7 +71,7 @@ class TypingTest {
      * @spec CHA-T4, CHA-T4a4, CHA-T4c
      */
     @Test
-    fun `Multiple calls to typing start within heartbeatThrottleMs, only one message is published`() = runTest {
+    fun `Multiple calls to typing start within heartbeatThrottle, only one message is published`() = runTest {
         val testScheduler = TestCoroutineScheduler()
         val dispatcher = StandardTestDispatcher(testScheduler)
         val scope = CoroutineScope(dispatcher)
@@ -98,11 +98,11 @@ class TypingTest {
         assertEquals(TypingEventType.Started.eventName, publishedMessage?.name)
         assertEquals(DEFAULT_CLIENT_ID, publishedMessage?.data)
 
-        // Advance time by 10 seconds ( heartbeatThrottleMs )
+        // Advance time by 10 seconds ( heartbeatThrottle )
         testScheduler.advanceTimeBy(11.seconds)
         testScheduler.runCurrent()
 
-        // Only one message should be published, since 10 second heartbeatThrottleMs is passed
+        // Only one message should be published, since 10 second heartbeatThrottle is passed
         scope.launch {
             repeat(5) {
                 typing.keystroke()
@@ -121,7 +121,7 @@ class TypingTest {
      * @spec CHA-T13, CHA-T10a1, CHA-T13b3
      */
     @Test
-    fun `On typingStart event received, heartbeatThrottleMs timeout is set, emits self stop event if no more event received`() = runTest {
+    fun `On typingStart event received, heartbeatThrottle timeout is set, emits self stop event if no more event received`() = runTest {
         val testScheduler = TestCoroutineScheduler()
         val dispatcher = StandardTestDispatcher(testScheduler)
         val typing = DefaultTyping(room, dispatcher)
@@ -138,7 +138,7 @@ class TypingTest {
         assertEquals(TypingEventType.Started, typingEvents[0].change.type)
         assertEquals(DEFAULT_CLIENT_ID, typingEvents[0].change.clientId)
 
-        // Emits stop event after 12 seconds, heartbeatThrottleMs (10 sec) + timeoutMs (2 sec) = 12 seconds
+        // Emits stop event after 12 seconds, heartbeatThrottle (10 sec) + timeoutMs (2 sec) = 12 seconds
         testScheduler.advanceTimeBy(12.seconds)
         testScheduler.runCurrent()
 
@@ -152,7 +152,7 @@ class TypingTest {
      * @spec CHA-T5, CHA-T14, CHA-T5e, CHA-T5d
      */
     @Test
-    fun `If typing stop is called, the heartbeatThrottleMs timeout is cancelled, the client sends stop event`() = runTest {
+    fun `If typing stop is called, the heartbeatThrottle timeout is cancelled, the client sends stop event`() = runTest {
         val typing = spyk(DefaultTyping(room))
 
         var publishedMessage: Message? = null

--- a/chat-android/src/test/java/com/ably/chat/TypingTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/TypingTest.kt
@@ -49,7 +49,7 @@ class TypingTest {
     }
 
     /**
-     * @spec CHA-T4a1
+     * @spec CHA-T4
      */
     @Test
     fun `when a typing start is called, the client publishes typing start ephemeral message`() = runTest {
@@ -67,6 +67,9 @@ class TypingTest {
         assertEquals(DEFAULT_CLIENT_ID, publishedMessage?.data)
     }
 
+    /**
+     * @spec CHA-T4, CHA-T4a4, CHA-T4c
+     */
     @Test
     fun `Multiple calls to typing start within heartbeatThrottleMs, only one message is published`() = runTest {
         val testScheduler = TestCoroutineScheduler()
@@ -115,7 +118,7 @@ class TypingTest {
     }
 
     /**
-     * @spec CHA-T4a2
+     * @spec CHA-T13, CHA-T10a1, CHA-T13b3
      */
     @Test
     fun `On typingStart event received, heartbeatThrottleMs timeout is set, emits self stop event if no more event received`() = runTest {
@@ -146,7 +149,7 @@ class TypingTest {
     }
 
     /**
-     * @spec CHA-T5b
+     * @spec CHA-T5, CHA-T14, CHA-T5e, CHA-T5d
      */
     @Test
     fun `If typing stop is called, the heartbeatThrottleMs timeout is cancelled, the client sends stop event`() = runTest {

--- a/chat-android/src/test/java/com/ably/chat/TypingTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/TypingTest.kt
@@ -61,7 +61,7 @@ class TypingTest {
             publishedMessage = firstArg()
             secondArg<CompletionListener>().onSuccess()
         }
-        typing.keyStroke()
+        typing.keystroke()
         verify(exactly = 1) { typingChannel.publish(any<Message>(), any()) }
         assertEquals(TypingEventType.Started.eventName, publishedMessage?.name)
         assertEquals(DEFAULT_CLIENT_ID, publishedMessage?.data)
@@ -84,12 +84,12 @@ class TypingTest {
 
         scope.launch {
             repeat(5) {
-                typing.keyStroke()
+                typing.keystroke()
             }
         }
         testScheduler.runCurrent()
 
-        coVerify(exactly = 5) { typing.keyStroke() }
+        coVerify(exactly = 5) { typing.keystroke() }
 
         verify(exactly = 1) { typingChannel.publish(any<Message>(), any()) }
         assertEquals(TypingEventType.Started.eventName, publishedMessage?.name)
@@ -102,12 +102,12 @@ class TypingTest {
         // Only one message should be published, since 10 second heartbeatThrottleMs is passed
         scope.launch {
             repeat(5) {
-                typing.keyStroke()
+                typing.keystroke()
             }
         }
         testScheduler.runCurrent()
 
-        coVerify(exactly = 10) { typing.keyStroke() }
+        coVerify(exactly = 10) { typing.keystroke() }
 
         verify(exactly = 2) { typingChannel.publish(any<Message>(), any()) }
         assertEquals(TypingEventType.Started.eventName, publishedMessage?.name)
@@ -150,10 +150,7 @@ class TypingTest {
      */
     @Test
     fun `If typing stop is called, the heartbeatThrottleMs timeout is cancelled, the client sends stop event`() = runTest {
-        val testScheduler = TestCoroutineScheduler()
-        val dispatcher = StandardTestDispatcher(testScheduler)
-        val scope = CoroutineScope(dispatcher)
-        val typing = spyk(DefaultTyping(room, dispatcher))
+        val typing = spyk(DefaultTyping(room))
 
         var publishedMessage: Message? = null
         every {
@@ -163,23 +160,15 @@ class TypingTest {
             secondArg<CompletionListener>().onSuccess()
         }
 
-        scope.launch {
-            typing.keyStroke()
-        }
+        typing.keystroke()
 
-        testScheduler.runCurrent()
-
-        coVerify(exactly = 1) { typing.keyStroke() }
+        coVerify(exactly = 1) { typing.keystroke() }
 
         verify(exactly = 1) { typingChannel.publish(any<Message>(), any()) }
         assertEquals(TypingEventType.Started.eventName, publishedMessage?.name)
         assertEquals(DEFAULT_CLIENT_ID, publishedMessage?.data)
 
-        scope.launch {
-            typing.stop()
-        }
-
-        testScheduler.runCurrent()
+        typing.stop()
 
         coVerify(exactly = 1) { typing.stop() }
 

--- a/chat-android/src/test/java/com/ably/chat/integration/TypingIntegrationTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/integration/TypingIntegrationTest.kt
@@ -1,6 +1,8 @@
 package com.ably.chat.integration
 
 import com.ably.chat.TypingEvent
+import com.ably.chat.TypingEventType
+import com.ably.chat.assertWaiter
 import com.ably.chat.buildRoomOptions
 import com.ably.chat.typing
 import java.util.UUID
@@ -13,8 +15,11 @@ import org.junit.Test
 
 class TypingIntegrationTest {
 
+    /**
+     * @spec CHA-T4, CHA-T9
+     */
     @Test
-    fun `should return typing indication for client`() = runTest {
+    fun `should return typing start indication for client`() = runTest {
         val chatClient1 = sandbox.createSandboxChatClient("client1")
         val chatClient2 = sandbox.createSandboxChatClient("client2")
         val roomId = UUID.randomUUID().toString()
@@ -24,14 +29,98 @@ class TypingIntegrationTest {
         val chatClient2Room = chatClient2.rooms.get(roomId, roomOptions)
         chatClient2Room.attach()
 
-        val deferredValue = CompletableDeferred<TypingEvent>()
+        assertEquals(emptySet<String>(), chatClient1Room.typing.get())
+        assertEquals(emptySet<String>(), chatClient2Room.typing.get())
+
+        val startTypingEventDeferred = CompletableDeferred<TypingEvent>()
         chatClient2Room.typing.subscribe {
-            deferredValue.complete(it)
+            startTypingEventDeferred.complete(it)
         }
         chatClient1Room.typing.keystroke()
-        val typingEvent = deferredValue.await()
-        assertEquals(setOf("client1"), typingEvent.currentlyTyping)
+        val startTypingEvent = startTypingEventDeferred.await()
+
+        assertEquals(setOf("client1"), startTypingEvent.currentlyTyping)
+        assertEquals("client1", startTypingEvent.change.clientId)
+        assertEquals(TypingEventType.Started, startTypingEvent.change.type)
+
+        assertEquals(setOf("client1"), chatClient1Room.typing.get())
         assertEquals(setOf("client1"), chatClient2Room.typing.get())
+    }
+
+    /**
+     * @spec CHA-T5, CHA-T9
+     */
+    @Test
+    fun `should return typing stop indication for clients`() = runTest {
+        // Set up 3 chat Clients
+        val chatClient1 = sandbox.createSandboxChatClient("client1")
+        val chatClient2 = sandbox.createSandboxChatClient("client2")
+        val chatClient3 = sandbox.createSandboxChatClient("client3")
+        val roomId = UUID.randomUUID().toString()
+        val roomOptions = buildRoomOptions { typing { heartbeatThrottle = 10.seconds } }
+        val chatClient1Room = chatClient1.rooms.get(roomId, roomOptions)
+        chatClient1Room.attach()
+        val chatClient2Room = chatClient2.rooms.get(roomId, roomOptions)
+        chatClient2Room.attach()
+        val chatClient3Room = chatClient3.rooms.get(roomId, roomOptions)
+        chatClient3Room.attach()
+
+        // Client 1, Client 2 starts typing
+        val startTypingEvents = mutableListOf<TypingEvent>()
+        chatClient2Room.typing.subscribe {
+            startTypingEvents.add(it)
+        }
+        chatClient1Room.typing.keystroke()
+        chatClient2Room.typing.keystroke()
+
+        // Two start typing events received
+        assertWaiter { startTypingEvents.size == 2 }
+
+        val startTypingEvent1 = startTypingEvents[0]
+        assertEquals(setOf("client1"), startTypingEvent1.currentlyTyping)
+        assertEquals("client1", startTypingEvent1.change.clientId)
+        assertEquals(TypingEventType.Started, startTypingEvent1.change.type)
+
+        val startTypingEvent2 = startTypingEvents[1]
+        assertEquals(setOf("client1", "client2"), startTypingEvent2.currentlyTyping)
+        assertEquals("client2", startTypingEvent2.change.clientId)
+        assertEquals(TypingEventType.Started, startTypingEvent2.change.type)
+
+        assertWaiter { chatClient1Room.typing.get() == setOf("client1", "client2") }
+        assertWaiter { chatClient2Room.typing.get() == setOf("client1", "client2") }
+        assertWaiter { chatClient3Room.typing.get() == setOf("client1", "client2") }
+
+        // Client 1 stops typing
+        val stopTypingEventDeferred1 = CompletableDeferred<TypingEvent>()
+        chatClient2Room.typing.subscribe {
+            stopTypingEventDeferred1.complete(it)
+        }
+        chatClient1Room.typing.stop()
+
+        val stopTypingEvent1 = stopTypingEventDeferred1.await()
+        assertEquals(setOf("client2"), stopTypingEvent1.currentlyTyping)
+        assertEquals("client1", stopTypingEvent1.change.clientId)
+        assertEquals(TypingEventType.Stopped, stopTypingEvent1.change.type)
+
+        assertWaiter { chatClient1Room.typing.get() == setOf("client2") }
+        assertWaiter { chatClient2Room.typing.get() == setOf("client2") }
+        assertWaiter { chatClient3Room.typing.get() == setOf("client2") }
+
+        // Client 2 stops typing
+        val stopTypingEventDeferred2 = CompletableDeferred<TypingEvent>()
+        chatClient2Room.typing.subscribe {
+            stopTypingEventDeferred2.complete(it)
+        }
+        chatClient2Room.typing.stop()
+
+        val stopTypingEvent2 = stopTypingEventDeferred2.await()
+        assertEquals(emptySet<String>(), stopTypingEvent2.currentlyTyping)
+        assertEquals("client2", stopTypingEvent2.change.clientId)
+        assertEquals(TypingEventType.Stopped, stopTypingEvent2.change.type)
+
+        assertWaiter { chatClient1Room.typing.get().isEmpty() }
+        assertWaiter { chatClient2Room.typing.get().isEmpty() }
+        assertWaiter { chatClient3Room.typing.get().isEmpty() }
     }
 
     companion object {

--- a/chat-android/src/test/java/com/ably/chat/integration/TypingIntegrationTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/integration/TypingIntegrationTest.kt
@@ -4,6 +4,7 @@ import com.ably.chat.TypingEvent
 import com.ably.chat.buildRoomOptions
 import com.ably.chat.typing
 import java.util.UUID
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -17,7 +18,7 @@ class TypingIntegrationTest {
         val chatClient1 = sandbox.createSandboxChatClient("client1")
         val chatClient2 = sandbox.createSandboxChatClient("client2")
         val roomId = UUID.randomUUID().toString()
-        val roomOptions = buildRoomOptions { typing { heartbeatThrottleMs = 10_000 } }
+        val roomOptions = buildRoomOptions { typing { heartbeatThrottle = 10.seconds } }
         val chatClient1Room = chatClient1.rooms.get(roomId, roomOptions)
         chatClient1Room.attach()
         val chatClient2Room = chatClient2.rooms.get(roomId, roomOptions)

--- a/chat-android/src/test/java/com/ably/chat/integration/TypingIntegrationTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/integration/TypingIntegrationTest.kt
@@ -27,7 +27,7 @@ class TypingIntegrationTest {
         chatClient2Room.typing.subscribe {
             deferredValue.complete(it)
         }
-        chatClient1Room.typing.keyStroke()
+        chatClient1Room.typing.keystroke()
         val typingEvent = deferredValue.await()
         assertEquals(setOf("client1"), typingEvent.currentlyTyping)
         assertEquals(setOf("client1"), chatClient2Room.typing.get())

--- a/chat-android/src/test/java/com/ably/chat/integration/TypingIntegrationTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/integration/TypingIntegrationTest.kt
@@ -27,7 +27,7 @@ class TypingIntegrationTest {
         chatClient2Room.typing.subscribe {
             deferredValue.complete(it)
         }
-        chatClient1Room.typing.start()
+        chatClient1Room.typing.keyStroke()
         val typingEvent = deferredValue.await()
         assertEquals(setOf("client1"), typingEvent.currentlyTyping)
         assertEquals(setOf("client1"), chatClient2Room.typing.get())

--- a/chat-android/src/test/java/com/ably/chat/integration/TypingIntegrationTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/integration/TypingIntegrationTest.kt
@@ -17,7 +17,7 @@ class TypingIntegrationTest {
         val chatClient1 = sandbox.createSandboxChatClient("client1")
         val chatClient2 = sandbox.createSandboxChatClient("client2")
         val roomId = UUID.randomUUID().toString()
-        val roomOptions = RoomOptions(typing = TypingOptions(timeoutMs = 10_000))
+        val roomOptions = RoomOptions(typing = TypingOptions(heartbeatThrottleMs = 10_000))
         val chatClient1Room = chatClient1.rooms.get(roomId, roomOptions)
         chatClient1Room.attach()
         val chatClient2Room = chatClient2.rooms.get(roomId, roomOptions)

--- a/chat-android/src/test/java/com/ably/chat/room/ConfigureRoomOptionsTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/room/ConfigureRoomOptionsTest.kt
@@ -8,6 +8,8 @@ import com.ably.chat.buildRoomOptions
 import com.ably.chat.typing
 import io.ably.lib.types.AblyException
 import io.mockk.mockk
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert
 import org.junit.Assert.assertThrows
@@ -32,7 +34,7 @@ class ConfigureRoomOptionsTest {
         // Room success when positive typing timeout
         val room = DefaultRoom(
             "1234",
-            buildRoomOptions { typing { heartbeatThrottleMs = 100 } },
+            buildRoomOptions { typing { heartbeatThrottle = 100.milliseconds } },
             mockRealtimeClient,
             chatApi,
             clientId,
@@ -43,9 +45,16 @@ class ConfigureRoomOptionsTest {
 
         // Room failure when negative timeout
         val exception = assertThrows(AblyException::class.java) {
-            DefaultRoom("1234", buildRoomOptions { typing { heartbeatThrottleMs = -1 } }, mockRealtimeClient, chatApi, clientId, logger)
+            DefaultRoom(
+                "1234",
+                buildRoomOptions { typing { heartbeatThrottle = 1.seconds.unaryMinus() } },
+                mockRealtimeClient,
+                chatApi,
+                clientId,
+                logger,
+            )
         }
-        Assert.assertEquals("Typing heartbeatThrottleMs must be greater than 0", exception.errorInfo.message)
+        Assert.assertEquals("Typing heartbeatThrottle must be greater than 0", exception.errorInfo.message)
         Assert.assertEquals(40_001, exception.errorInfo.code)
         Assert.assertEquals(400, exception.errorInfo.statusCode)
     }

--- a/chat-android/src/test/java/com/ably/chat/room/ConfigureRoomOptionsTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/room/ConfigureRoomOptionsTest.kt
@@ -29,15 +29,30 @@ class ConfigureRoomOptionsTest {
         val chatApi = mockk<ChatApi>(relaxed = true)
 
         // Room success when positive typing timeout
-        val room = DefaultRoom("1234", RoomOptions(typing = TypingOptions(timeoutMs = 100)), mockRealtimeClient, chatApi, clientId, logger)
+        val room =
+            DefaultRoom(
+                "1234",
+                RoomOptions(typing = TypingOptions(heartbeatThrottleMs = 100)),
+                mockRealtimeClient,
+                chatApi,
+                clientId,
+                logger,
+            )
         Assert.assertNotNull(room)
         Assert.assertEquals(RoomStatus.Initialized, room.status)
 
         // Room failure when negative timeout
         val exception = assertThrows(AblyException::class.java) {
-            DefaultRoom("1234", RoomOptions(typing = TypingOptions(timeoutMs = -1)), mockRealtimeClient, chatApi, clientId, logger)
+            DefaultRoom(
+                "1234",
+                RoomOptions(typing = TypingOptions(heartbeatThrottleMs = -1)),
+                mockRealtimeClient,
+                chatApi,
+                clientId,
+                logger,
+            )
         }
-        Assert.assertEquals("Typing timeout must be greater than 0", exception.errorInfo.message)
+        Assert.assertEquals("Typing heartbeatThrottleMs must be greater than 0", exception.errorInfo.message)
         Assert.assertEquals(40_001, exception.errorInfo.code)
         Assert.assertEquals(400, exception.errorInfo.statusCode)
     }

--- a/chat-android/src/test/java/com/ably/chat/room/RoomGetTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/room/RoomGetTest.kt
@@ -91,7 +91,7 @@ class RoomGetTest {
         val room5 = rooms.get(
             "7890",
             RoomOptions(
-                typing = TypingOptions(timeoutMs = 1500),
+                typing = TypingOptions(heartbeatThrottleMs = 1500),
                 presence = PresenceOptions(
                     enter = true,
                     subscribe = false,
@@ -104,7 +104,7 @@ class RoomGetTest {
         val room6 = rooms.get(
             "7890",
             RoomOptions(
-                typing = TypingOptions(timeoutMs = 1500),
+                typing = TypingOptions(heartbeatThrottleMs = 1500),
                 presence = PresenceOptions(
                     enter = true,
                     subscribe = false,

--- a/chat-android/src/test/java/com/ably/chat/room/RoomGetTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/room/RoomGetTest.kt
@@ -17,6 +17,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.spyk
 import io.mockk.verify
+import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.Channel
@@ -91,7 +92,7 @@ class RoomGetTest {
         Assert.assertEquals(room3, room4)
 
         val room5 = rooms.get("7890") {
-            typing { heartbeatThrottleMs = 1500 }
+            typing { heartbeatThrottle = 1500.milliseconds }
             presence {
                 enter = true
                 subscribe = false
@@ -102,7 +103,7 @@ class RoomGetTest {
         Assert.assertEquals(room5, rooms.RoomIdToRoom["7890"])
 
         val room6 = rooms.get("7890") {
-            typing { heartbeatThrottleMs = 1500 }
+            typing { heartbeatThrottle = 1500.milliseconds }
             presence {
                 enter = true
                 subscribe = false

--- a/chat-android/src/test/java/com/ably/chat/room/RoomTestHelpers.kt
+++ b/chat-android/src/test/java/com/ably/chat/room/RoomTestHelpers.kt
@@ -14,7 +14,10 @@ import com.ably.chat.RoomLifecycleManager
 import com.ably.chat.RoomOptions
 import com.ably.chat.RoomStatusEventEmitter
 import com.ably.chat.Rooms
+import com.ably.chat.Typing
+import com.ably.chat.TypingEventType
 import com.ably.chat.getPrivateField
+import com.ably.chat.invokePrivateMethod
 import com.ably.chat.invokePrivateSuspendMethod
 import com.ably.pubsub.RealtimeChannel
 import com.ably.pubsub.RealtimeClient
@@ -103,6 +106,9 @@ internal fun RoomLifecycleManager.atomicCoroutineScope(): AtomicCoroutineScope =
 
 internal suspend fun RoomLifecycleManager.retry(exceptContributor: ContributesToRoomLifecycle) =
     invokePrivateSuspendMethod<Unit>("doRetry", exceptContributor)
+
+internal fun Typing.processEvent(eventType: TypingEventType, clientId: String) =
+    invokePrivateMethod<Unit>("processEvent", eventType, clientId)
 
 internal suspend fun RoomLifecycleManager.atomicRetry(exceptContributor: ContributesToRoomLifecycle) {
     atomicCoroutineScope().async(LifecycleOperationPrecedence.Internal.priority) {

--- a/chat-android/src/test/java/com/ably/chat/room/RoomTestHelpers.kt
+++ b/chat-android/src/test/java/com/ably/chat/room/RoomTestHelpers.kt
@@ -57,6 +57,7 @@ fun createMockRealtimeChannel(channelName: String = "channel"): RealtimeChannel 
         every { subscribe(any()) } returns mockk(relaxUnitFun = true)
     }
     every { subscribe(any<String>(), any()) } returns mockk(relaxUnitFun = true)
+    every { subscribe(any<List<String>>(), any()) } returns mockk(relaxUnitFun = true)
     every { subscribe(any()) } returns mockk(relaxUnitFun = true)
 }
 

--- a/chat-android/src/test/java/com/ably/chat/room/RoomTestHelpers.kt
+++ b/chat-android/src/test/java/com/ably/chat/room/RoomTestHelpers.kt
@@ -108,7 +108,7 @@ internal suspend fun RoomLifecycleManager.retry(exceptContributor: ContributesTo
     invokePrivateSuspendMethod<Unit>("doRetry", exceptContributor)
 
 internal fun Typing.processEvent(eventType: TypingEventType, clientId: String) =
-    invokePrivateMethod<Unit>("processEvent", eventType, clientId)
+    invokePrivateMethod<Unit>("processReceivedTypingEvents", eventType, clientId)
 
 internal suspend fun RoomLifecycleManager.atomicRetry(exceptContributor: ContributesToRoomLifecycle) {
     atomicCoroutineScope().async(LifecycleOperationPrecedence.Internal.priority) {

--- a/chat-android/src/test/java/com/ably/chat/room/RoomTestHelpers.kt
+++ b/chat-android/src/test/java/com/ably/chat/room/RoomTestHelpers.kt
@@ -19,6 +19,7 @@ import com.ably.chat.TypingEventType
 import com.ably.chat.getPrivateField
 import com.ably.chat.invokePrivateMethod
 import com.ably.chat.invokePrivateSuspendMethod
+import com.ably.chat.setPrivateField
 import com.ably.pubsub.RealtimeChannel
 import com.ably.pubsub.RealtimeClient
 import io.ably.lib.realtime.Channel
@@ -29,7 +30,9 @@ import io.ably.lib.util.EventEmitter
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.spyk
+import kotlin.time.TimeSource.Monotonic.ValueTimeMark
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Job
 import io.ably.lib.realtime.Channel as AblyRealtimeChannel
 
 const val DEFAULT_ROOM_ID = "1234"
@@ -106,6 +109,12 @@ internal fun RoomLifecycleManager.atomicCoroutineScope(): AtomicCoroutineScope =
 
 internal suspend fun RoomLifecycleManager.retry(exceptContributor: ContributesToRoomLifecycle) =
     invokePrivateSuspendMethod<Unit>("doRetry", exceptContributor)
+
+internal var Typing.TypingHeartbeatStarted: ValueTimeMark?
+    get() = getPrivateField("typingHeartbeatStarted")
+    set(value) = setPrivateField("typingHeartbeatStarted", value)
+
+internal val Typing.TypingStartEventPrunerJobs get() = getPrivateField<Map<String, Job>>("typingStartEventPrunerJobs")
 
 internal fun Typing.processEvent(eventType: TypingEventType, clientId: String) =
     invokePrivateMethod<Unit>("processReceivedTypingEvents", eventType, clientId)

--- a/chat-extensions-compose/src/test/kotlin/com/ably/chat/extensions/compose/TypingTest.kt
+++ b/chat-extensions-compose/src/test/kotlin/com/ably/chat/extensions/compose/TypingTest.kt
@@ -29,10 +29,22 @@ class TypingTest {
             room.collectAsCurrentlyTyping()
         }.test {
             assertEquals(emptySet<String>(), awaitItem())
-            val change = TypingEvent.TypingChange("client_1", TypingEventType.Started)
-            typing.emit(TypingEvent(currentlyTyping = setOf("client_1", "client_2"), change))
+            val change = object : TypingEvent.Change {
+                override val type: TypingEventType = TypingEventType.Started
+                override val clientId: String = "client_1"
+            }
+            val typingEvent1 = object : TypingEvent {
+                override val currentlyTyping: Set<String> = setOf("client_1", "client_2")
+                override val change: TypingEvent.Change = change
+            }
+            typing.emit(typingEvent1)
             assertEquals(setOf("client_1", "client_2"), awaitItem())
-            typing.emit(TypingEvent(currentlyTyping = setOf("client_3"), change))
+
+            val typingEvent2 = object : TypingEvent {
+                override val currentlyTyping: Set<String> = setOf("client_3")
+                override val change: TypingEvent.Change = change
+            }
+            typing.emit(typingEvent2)
             assertEquals(setOf("client_3"), awaitItem())
             cancel()
         }

--- a/chat-extensions-compose/src/test/kotlin/com/ably/chat/extensions/compose/TypingTest.kt
+++ b/chat-extensions-compose/src/test/kotlin/com/ably/chat/extensions/compose/TypingTest.kt
@@ -7,6 +7,7 @@ import com.ably.chat.Room
 import com.ably.chat.Subscription
 import com.ably.chat.Typing
 import com.ably.chat.TypingEvent
+import com.ably.chat.TypingEventType
 import com.ably.chat.annotations.ExperimentalChatApi
 import io.mockk.every
 import io.mockk.mockk
@@ -28,9 +29,10 @@ class TypingTest {
             room.collectAsCurrentlyTyping()
         }.test {
             assertEquals(emptySet<String>(), awaitItem())
-            typing.emit(TypingEvent(currentlyTyping = setOf("client_1", "client_2")))
+            val change = TypingEvent.TypingChange("client_1", TypingEventType.Started)
+            typing.emit(TypingEvent(currentlyTyping = setOf("client_1", "client_2"), change))
             assertEquals(setOf("client_1", "client_2"), awaitItem())
-            typing.emit(TypingEvent(currentlyTyping = setOf("client_3")))
+            typing.emit(TypingEvent(currentlyTyping = setOf("client_3"), change))
             assertEquals(setOf("client_3"), awaitItem())
             cancel()
         }

--- a/chat-extensions-compose/src/test/kotlin/com/ably/chat/extensions/compose/TypingTest.kt
+++ b/chat-extensions-compose/src/test/kotlin/com/ably/chat/extensions/compose/TypingTest.kt
@@ -67,7 +67,3 @@ class EmittingTyping(mock: Typing) : Typing by mock {
         }
     }
 }
-
-fun TypingEvent(currentlyTyping: Set<String>): TypingEvent = mockk {
-    every { this@mockk.currentlyTyping } returns currentlyTyping
-}

--- a/example/src/main/java/com/ably/chat/example/MainActivity.kt
+++ b/example/src/main/java/com/ably/chat/example/MainActivity.kt
@@ -221,7 +221,7 @@ fun Chat(room: Room, modifier: Modifier = Modifier) {
             onMessageChange = {
                 messageText = it
                 coroutineScope.launch {
-                    room.typing.keyStroke()
+                    room.typing.keystroke()
                 }
             },
             onSendClick = {

--- a/example/src/main/java/com/ably/chat/example/MainActivity.kt
+++ b/example/src/main/java/com/ably/chat/example/MainActivity.kt
@@ -224,6 +224,9 @@ fun Chat(room: Room, modifier: Modifier = Modifier) {
             },
             onSendClick = {
                 sending = true
+                coroutineScope.launch {
+                    room.typing.stop()
+                }
                 when {
                     updating -> handleEdit()
                     else -> handleSend()

--- a/example/src/main/java/com/ably/chat/example/MainActivity.kt
+++ b/example/src/main/java/com/ably/chat/example/MainActivity.kt
@@ -221,7 +221,7 @@ fun Chat(room: Room, modifier: Modifier = Modifier) {
             onMessageChange = {
                 messageText = it
                 coroutineScope.launch {
-                    room.typing.start()
+                    room.typing.keyStroke()
                 }
             },
             onSendClick = {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 # https://docs.gradle.org/current/userguide/platforms.html#sub::toml-dependencies-format
 
 [versions]
-ably = "1.2.50"
+ably = "1.2.51"
 junit = "4.13.2"
 agp = "8.5.2"
 detekt = "1.23.6"


### PR DESCRIPTION
Fixed https://github.com/ably/ably-chat-kotlin/issues/118

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced typing indicators now display distinct "Started" and "Stopped" states, providing clearer visual feedback during conversations.
  - Introduced a new throttle mechanism for typing events, replacing the previous timeout-based approach.
  - Added a new method for managing typing events, allowing for improved control over typing state during message sending.

- **Enhancements**
  - Improved responsiveness by switching to keystroke-based event updates, ensuring more accurate and timely typing status.

- **Dependency Updates**
  - Upgraded our core chat library from version 1.2.50 to 1.2.51 for enhanced performance, stability, and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->