### PR TITLE
[ECO-5256] refactor: getting rid of data classes from public API

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,6 +13,7 @@ plugins {
 
 dependencies {
     detektPlugins(libs.detekt.formatting)
+    detektPlugins(libs.detekt.rules.libraries)
 }
 
 allprojects {

--- a/chat-android/src/main/java/com/ably/chat/ChatApi.kt
+++ b/chat-android/src/main/java/com/ably/chat/ChatApi.kt
@@ -45,7 +45,7 @@ internal class ChatApi(
             val operation = messageJsonObject.getAsJsonObject(MessageProperty.Operation)
             latestAction?.let { action ->
                 logger.debug("getMessages();", context = mapOf("roomId" to roomId, "message" to messageJsonObject.toString()))
-                Message(
+                DefaultMessage(
                     serial = messageJsonObject.requireString(MessageProperty.Serial),
                     clientId = messageJsonObject.requireString(MessageProperty.ClientId),
                     roomId = messageJsonObject.requireString(MessageProperty.RoomId),
@@ -78,7 +78,7 @@ internal class ChatApi(
             val createdAt = it.requireLong(MessageProperty.CreatedAt)
             logger.debug("sendMessage();", context = mapOf("roomId" to roomId, "response" to it.toString()))
             // CHA-M3a
-            Message(
+            DefaultMessage(
                 serial = serial,
                 clientId = clientId,
                 roomId = roomId,
@@ -110,7 +110,7 @@ internal class ChatApi(
             val timestamp = it.requireLong(MessageProperty.Timestamp)
             logger.debug("updateMessage();", context = mapOf("messageSerial" to message.serial, "response" to it.toString()))
             // CHA-M8b
-            Message(
+            DefaultMessage(
                 serial = message.serial,
                 clientId = clientId,
                 roomId = message.roomId,
@@ -142,7 +142,7 @@ internal class ChatApi(
             val timestamp = it.requireLong(MessageProperty.Timestamp)
             logger.debug("deleteMessage();", context = mapOf("messageSerial" to message.serial, "response" to it.toString()))
             // CHA-M9b
-            Message(
+            DefaultMessage(
                 serial = message.serial,
                 clientId = clientId,
                 roomId = message.roomId,
@@ -165,7 +165,7 @@ internal class ChatApi(
         logger.trace("getOccupancy();", context = mapOf("roomId" to roomId))
         return this.makeAuthorizedRequest("/chat/v2/rooms/$roomId/occupancy", HttpMethod.Get)?.let {
             logger.debug("getOccupancy();", context = mapOf("roomId" to roomId, "response" to it.toString()))
-            OccupancyEvent(
+            DefaultOccupancyEvent(
                 connections = it.requireInt("connections"),
                 presenceMembers = it.requireInt("presenceMembers"),
             )

--- a/chat-android/src/main/java/com/ably/chat/ChatClientOptions.kt
+++ b/chat-android/src/main/java/com/ably/chat/ChatClientOptions.kt
@@ -1,18 +1,29 @@
 package com.ably.chat
 
+import com.ably.chat.annotations.ChatDsl
+
 /**
  * Configuration options for the chat client.
  */
-public data class ChatClientOptions(
+public interface ChatClientOptions {
     /**
      * A custom log handler that will be used to log messages from the client.
      * @defaultValue The client will log messages to the console.
      */
-    val logHandler: LogHandler? = null,
+    public val logHandler: LogHandler?
 
     /**
      * The minimum log level at which messages will be logged.
      * @defaultValue LogLevel.Error
      */
-    val logLevel: LogLevel = LogLevel.Error,
-)
+    public val logLevel: LogLevel
+}
+
+@ChatDsl
+public class MutableChatClientOptions : ChatClientOptions {
+    override var logHandler: LogHandler? = null
+    override var logLevel: LogLevel = LogLevel.Error
+}
+
+public fun buildChatClientOptions(init: MutableChatClientOptions.() -> Unit = {}): ChatClientOptions =
+    MutableChatClientOptions().apply(init)

--- a/chat-android/src/main/java/com/ably/chat/Connection.kt
+++ b/chat-android/src/main/java/com/ably/chat/Connection.kt
@@ -57,28 +57,35 @@ public enum class ConnectionStatus(public val stateName: String) {
 /**
  * Represents a change in the status of the connection.
  */
-public data class ConnectionStatusChange(
+public interface ConnectionStatusChange {
     /**
      * The new status of the connection.
      */
-    val current: ConnectionStatus,
+    public val current: ConnectionStatus
 
     /**
      * The previous status of the connection.
      */
-    val previous: ConnectionStatus,
+    public val previous: ConnectionStatus
 
     /**
      * An error that provides a reason why the connection has
      * entered the new status, if applicable.
      */
-    val error: ErrorInfo? = null,
+    public val error: ErrorInfo?
 
     /**
      * The time in milliseconds that the client will wait before attempting to reconnect.
      */
-    val retryIn: Long? = null,
-)
+    public val retryIn: Long?
+}
+
+internal data class DefaultConnectionStatusChange(
+    override val current: ConnectionStatus,
+    override val previous: ConnectionStatus,
+    override val error: ErrorInfo? = null,
+    override val retryIn: Long? = null,
+) : ConnectionStatusChange
 
 /**
  * Represents a connection to Ably.
@@ -182,7 +189,7 @@ internal class DefaultConnection(
         this.error = error
         logger.info("Connection state changed from ${previous.stateName} to ${nextStatus.stateName}")
         emitStateChange(
-            ConnectionStatusChange(
+            DefaultConnectionStatusChange(
                 current = status,
                 previous = previous,
                 error = error,

--- a/chat-android/src/main/java/com/ably/chat/Logger.kt
+++ b/chat-android/src/main/java/com/ably/chat/Logger.kt
@@ -9,11 +9,17 @@ public fun interface LogHandler {
     public fun log(message: String, level: LogLevel, throwable: Throwable?, context: LogContext)
 }
 
-public data class LogContext(
-    val tag: String,
-    val staticContext: Map<String, String> = mapOf(),
-    val dynamicContext: Map<String, () -> String> = mapOf(),
-)
+public interface LogContext {
+    public val tag: String
+    public val staticContext: Map<String, String>
+    public val dynamicContext: Map<String, () -> String>
+}
+
+internal class DefaultLogContext(
+    override val tag: String,
+    override val staticContext: Map<String, String> = mapOf(),
+    override val dynamicContext: Map<String, () -> String> = mapOf(),
+) : LogContext
 
 internal interface Logger {
     val context: LogContext
@@ -72,7 +78,7 @@ internal fun LogContext.mergeWith(
     staticContext: Map<String, String> = mapOf(),
     dynamicContext: Map<String, () -> String> = mapOf(),
 ): LogContext {
-    return LogContext(
+    return DefaultLogContext(
         tag = tag ?: this.tag,
         staticContext = this.staticContext + staticContext,
         dynamicContext = this.dynamicContext + dynamicContext,

--- a/chat-android/src/main/java/com/ably/chat/Occupancy.kt
+++ b/chat-android/src/main/java/com/ably/chat/Occupancy.kt
@@ -66,17 +66,22 @@ public fun Occupancy.asFlow(): Flow<OccupancyEvent> = transformCallbackAsFlow {
  *
  * (CHA-O2)
  */
-public data class OccupancyEvent(
+public interface OccupancyEvent {
     /**
      * The number of connections to the chat room.
      */
-    val connections: Int,
+    public val connections: Int
 
     /**
      * The number of presence members in the chat room - members who have entered presence.
      */
-    val presenceMembers: Int,
-)
+    public val presenceMembers: Int
+}
+
+internal data class DefaultOccupancyEvent(
+    override val connections: Int,
+    override val presenceMembers: Int,
+) : OccupancyEvent
 
 private const val META_OCCUPANCY_EVENT_NAME = "[meta]occupancy"
 
@@ -205,7 +210,7 @@ internal class DefaultOccupancy(
 
         eventBus.tryEmit(
             // (CHA-04c)
-            OccupancyEvent(
+            DefaultOccupancyEvent(
                 connections = connections.asInt,
                 presenceMembers = presenceMembers.asInt,
             ),

--- a/chat-android/src/main/java/com/ably/chat/Reaction.kt
+++ b/chat-android/src/main/java/com/ably/chat/Reaction.kt
@@ -13,34 +13,43 @@ public typealias ReactionMetadata = Metadata
 /**
  * Represents a room-level reaction.
  */
-public data class Reaction(
+public interface Reaction {
     /**
      * The type of the reaction, for example "like" or "love".
      */
-    val type: String,
+    public val type: String
 
     /**
      * Metadata of the reaction. If no metadata was set this is an empty object.
      */
-    val metadata: ReactionMetadata?,
+    public val metadata: ReactionMetadata
 
     /**
      * Headers of the reaction. If no headers were set this is an empty object.
      */
-    val headers: ReactionHeaders = mapOf(),
+    public val headers: ReactionHeaders
 
     /**
      * The timestamp at which the reaction was sent.
      */
-    val createdAt: Long,
+    public val createdAt: Long
 
     /**
      * The clientId of the user who sent the reaction.
      */
-    val clientId: String,
+    public val clientId: String
 
     /**
      * Whether the reaction was sent by the current user.
      */
-    val isSelf: Boolean,
-)
+    public val isSelf: Boolean
+}
+
+internal data class DefaultReaction(
+    override val type: String,
+    override val metadata: ReactionMetadata,
+    override val headers: ReactionHeaders,
+    override val createdAt: Long,
+    override val clientId: String,
+    override val isSelf: Boolean,
+) : Reaction

--- a/chat-android/src/main/java/com/ably/chat/RoomOptions.kt
+++ b/chat-android/src/main/java/com/ably/chat/RoomOptions.kt
@@ -1,61 +1,62 @@
 package com.ably.chat
 
+import com.ably.chat.annotations.ChatDsl
 import io.ably.lib.types.ChannelMode
 import io.ably.lib.types.ChannelOptions
 
 /**
  * Represents the options for a given chat room.
  */
-public data class RoomOptions(
+public interface RoomOptions {
     /**
      * The presence options for the room. To enable presence in the room, set this property. You may
-     * use [RoomOptionsDefaults.presence] to enable presence with default options.
+     * use `rooms.get("ROOM_NAME") { presence() }` to enable presence with default options.
      * @defaultValue undefined
      */
-    val presence: PresenceOptions? = null,
+    public val presence: PresenceOptions?
 
     /**
      * The typing options for the room. To enable typing in the room, set this property. You may use
-     * [RoomOptionsDefaults.typing] to enable typing with default options.
+     * `rooms.get("ROOM_NAME") { typing() }`to enable typing with default options.
      */
-    val typing: TypingOptions? = null,
+    public val typing: TypingOptions?
 
     /**
      * The reactions options for the room. To enable reactions in the room, set this property. You may use
-     * [RoomOptionsDefaults.reactions] to enable reactions with default options.
+     * `rooms.get("ROOM_NAME") { reactions() }` to enable reactions with default options.
      */
-    val reactions: RoomReactionsOptions? = null,
+    public val reactions: RoomReactionsOptions?
 
     /**
      * The occupancy options for the room. To enable occupancy in the room, set this property. You may use
-     * [RoomOptionsDefaults.occupancy] to enable occupancy with default options.
+     * `rooms.get("ROOM_NAME") { occupancy() }` to enable occupancy with default options.
      */
-    val occupancy: OccupancyOptions? = null,
-) {
+    public val occupancy: OccupancyOptions?
+
     public companion object {
         /**
          * Supports all room options with default values
          */
-        public val default: RoomOptions = RoomOptions(
-            typing = TypingOptions(),
-            presence = PresenceOptions(),
-            reactions = RoomReactionsOptions(),
-            occupancy = OccupancyOptions(),
-        )
+        public val AllFeaturesEnabled: RoomOptions = buildRoomOptions {
+            typing()
+            presence()
+            reactions()
+            occupancy()
+        }
     }
 }
 
 /**
  * Represents the presence options for a chat room.
  */
-public data class PresenceOptions(
+public interface PresenceOptions {
     /**
      * Whether the underlying Realtime channel should use the presence enter mode, allowing entry into presence.
      * This property does not affect the presence lifecycle, and users must still call [Presence.enter]
      * in order to enter presence.
      * @defaultValue true
      */
-    val enter: Boolean = true,
+    public val enter: Boolean
 
     /**
      * Whether the underlying Realtime channel should use the presence subscribe mode, allowing subscription to presence.
@@ -63,20 +64,20 @@ public data class PresenceOptions(
      * in order to subscribe to presence.
      * @defaultValue true
      */
-    val subscribe: Boolean = true,
-)
+    public val subscribe: Boolean
+}
 
 /**
  * Represents the typing options for a chat room.
  */
-public data class TypingOptions(
+public interface TypingOptions {
     /**
      * The timeout for typing events in milliseconds. If typing.start() is not called for this amount of time, a stop
      * typing event will be fired, resulting in the user being removed from the currently typing set.
      * @defaultValue 5000
      */
-    val timeoutMs: Long = 5000,
-)
+    public val timeoutMs: Long
+}
 
 /**
  * Represents the reactions options for a chat room.
@@ -84,10 +85,7 @@ public data class TypingOptions(
  * Note: This class is currently empty but allows for future extensions
  * while maintaining backward compatibility.
  */
-public class RoomReactionsOptions {
-    override fun equals(other: Any?): Boolean = other is RoomReactionsOptions
-    override fun hashCode(): Int = javaClass.hashCode()
-}
+public interface RoomReactionsOptions
 
 /**
  * Represents the occupancy options for a chat room.
@@ -95,10 +93,86 @@ public class RoomReactionsOptions {
  * Note: This class is currently empty but allows for future extensions
  * while maintaining backward compatibility.
  */
-public class OccupancyOptions {
-    override fun equals(other: Any?): Boolean = other is OccupancyOptions
-    override fun hashCode(): Int = javaClass.hashCode()
+public interface OccupancyOptions
+
+@ChatDsl
+public class MutableRoomOptions : RoomOptions {
+    override var presence: MutablePresenceOptions? = null
+    override var typing: MutableTypingOptions? = null
+    override var reactions: MutableRoomReactionsOptions? = null
+    override var occupancy: MutableOccupancyOptions? = null
 }
+
+@ChatDsl
+public class MutablePresenceOptions : PresenceOptions {
+    override var enter: Boolean = true
+    override var subscribe: Boolean = true
+}
+
+@ChatDsl
+public class MutableTypingOptions : TypingOptions {
+    override var timeoutMs: Long = 5000
+}
+
+@ChatDsl
+public class MutableRoomReactionsOptions : RoomReactionsOptions
+
+@ChatDsl
+public class MutableOccupancyOptions : OccupancyOptions
+
+public fun buildRoomOptions(init: MutableRoomOptions.() -> Unit = {}): RoomOptions =
+    MutableRoomOptions().apply(init).asEquatable()
+
+public fun MutableRoomOptions.presence(init: MutablePresenceOptions.() -> Unit = {}) {
+    this.presence = MutablePresenceOptions().apply(init)
+}
+
+public fun MutableRoomOptions.typing(init: MutableTypingOptions.() -> Unit = {}) {
+    this.typing = MutableTypingOptions().apply(init)
+}
+
+public fun MutableRoomOptions.reactions(init: MutableRoomReactionsOptions.() -> Unit = {}) {
+    this.reactions = MutableRoomReactionsOptions().apply(init)
+}
+
+public fun MutableRoomOptions.occupancy(init: MutableOccupancyOptions.() -> Unit = {}) {
+    this.occupancy = MutableOccupancyOptions().apply(init)
+}
+
+internal data class EquatableRoomOptions(
+    override val presence: PresenceOptions? = null,
+    override val typing: TypingOptions? = null,
+    override val reactions: RoomReactionsOptions? = null,
+    override val occupancy: OccupancyOptions? = null,
+) : RoomOptions
+
+internal data class EquatablePresenceOptions(
+    override val enter: Boolean,
+    override val subscribe: Boolean,
+) : PresenceOptions
+
+internal data class EquatableTypingOptions(
+    override val timeoutMs: Long,
+) : TypingOptions
+
+internal data object EquatableRoomReactionsOptions : RoomReactionsOptions
+internal data object EquatableOccupancyOptions : OccupancyOptions
+
+internal fun MutableRoomOptions.asEquatable() = EquatableRoomOptions(
+    presence = presence?.asEquatable(),
+    typing = typing?.asEquatable(),
+    reactions = reactions?.let { EquatableRoomReactionsOptions },
+    occupancy = occupancy?.let { EquatableOccupancyOptions },
+)
+
+internal fun MutablePresenceOptions.asEquatable() = EquatablePresenceOptions(
+    enter = enter,
+    subscribe = subscribe,
+)
+
+internal fun MutableTypingOptions.asEquatable() = EquatableTypingOptions(
+    timeoutMs = timeoutMs,
+)
 
 /**
  * Throws AblyException for invalid room configuration.
@@ -106,8 +180,8 @@ public class OccupancyOptions {
  */
 internal fun RoomOptions.validateRoomOptions(logger: Logger) {
     typing?.let {
-        if (typing.timeoutMs <= 0) {
-            logger.error("Typing timeout must be greater than 0, found ${typing.timeoutMs}")
+        if (it.timeoutMs <= 0) {
+            logger.error("Typing timeout must be greater than 0, found ${it.timeoutMs}")
             throw ablyException("Typing timeout must be greater than 0", ErrorCode.InvalidRequestBody)
         }
     }
@@ -121,7 +195,7 @@ internal fun RoomOptions.validateRoomOptions(logger: Logger) {
  */
 internal fun RoomOptions.messagesChannelOptions(): ChannelOptions {
     return ChatChannelOptions {
-        presence?.let {
+        presence?.let { presence ->
             val channelModes = buildList {
                 // We should have this modes for regular messages
                 add(ChannelMode.publish)

--- a/chat-android/src/main/java/com/ably/chat/RoomReactions.kt
+++ b/chat-android/src/main/java/com/ably/chat/RoomReactions.kt
@@ -160,11 +160,11 @@ internal class DefaultRoomReactions(
             val data = pubSubMessage.data as? JsonObject ?: throw AblyException.fromErrorInfo(
                 ErrorInfo("Unrecognized Pub/Sub channel's message for `roomReaction` event", HttpStatusCode.InternalServerError),
             )
-            val reaction = Reaction(
+            val reaction = DefaultReaction(
                 type = data.requireString("type"),
                 createdAt = pubSubMessage.timestamp,
                 clientId = pubSubMessage.clientId,
-                metadata = data.getAsJsonObject("metadata"),
+                metadata = data.getAsJsonObject("metadata") ?: ReactionMetadata(),
                 headers = pubSubMessage.extras?.asJsonObject()?.get("headers")?.toMap() ?: mapOf(),
                 isSelf = pubSubMessage.clientId == room.clientId,
             )

--- a/chat-android/src/main/java/com/ably/chat/RoomStatus.kt
+++ b/chat-android/src/main/java/com/ably/chat/RoomStatus.kt
@@ -67,23 +67,29 @@ public enum class RoomStatus(public val stateName: String) {
  * Represents a change in the status of the room.
  * (CHA-RS4)
  */
-public data class RoomStatusChange(
+public interface RoomStatusChange {
     /**
      * The new status of the room.
      */
-    val current: RoomStatus,
+    public val current: RoomStatus
 
     /**
      * The previous status of the room.
      */
-    val previous: RoomStatus,
+    public val previous: RoomStatus
 
     /**
      * An error that provides a reason why the room has
      * entered the new status, if applicable.
      */
-    val error: ErrorInfo? = null,
-)
+    public val error: ErrorInfo?
+}
+
+internal data class DefaultRoomStatusChange(
+    override val current: RoomStatus,
+    override val previous: RoomStatus,
+    override val error: ErrorInfo? = null,
+) : RoomStatusChange
 
 /**
  * Represents the status of a Room.
@@ -196,7 +202,7 @@ internal class DefaultRoomLifecycle(logger: Logger) : InternalRoomLifecycle {
     }
 
     internal fun setStatus(status: RoomStatus, error: ErrorInfo? = null) {
-        val change = RoomStatusChange(status, _status, error)
+        val change = DefaultRoomStatusChange(status, _status, error)
         _status = change.current
         _error = change.error
         internalEmitter.emit(change.current, change)

--- a/chat-android/src/main/java/com/ably/chat/Rooms.kt
+++ b/chat-android/src/main/java/com/ably/chat/Rooms.kt
@@ -37,7 +37,7 @@ public interface Rooms {
      * @returns Room A new or existing Room object.
      * Spec: CHA-RC1f
      */
-    public suspend fun get(roomId: String, options: RoomOptions = RoomOptions()): Room
+    public suspend fun get(roomId: String, options: RoomOptions = buildRoomOptions()): Room
 
     /**
      * Release the Room object if it exists. This method only releases the reference
@@ -54,6 +54,8 @@ public interface Rooms {
      */
     public suspend fun release(roomId: String)
 }
+
+public suspend fun Rooms.get(roomId: String, initOptions: MutableRoomOptions.() -> Unit): Room = get(roomId, buildRoomOptions(initOptions))
 
 /**
  * Manages the chat rooms.
@@ -179,5 +181,5 @@ internal class DefaultRooms(
      * Spec: CHA-RC1f3
      */
     private fun makeRoom(roomId: String, options: RoomOptions): DefaultRoom =
-        DefaultRoom(roomId, options.copy(), realtimeClient, chatApi, clientId, logger)
+        DefaultRoom(roomId, options, realtimeClient, chatApi, clientId, logger)
 }

--- a/chat-android/src/main/java/com/ably/chat/Typing.kt
+++ b/chat-android/src/main/java/com/ably/chat/Typing.kt
@@ -97,7 +97,11 @@ public fun Typing.asFlow(): Flow<TypingEvent> = transformCallbackAsFlow {
 /**
  * Represents a typing event.
  */
-public data class TypingEvent(val currentlyTyping: Set<String>)
+public interface TypingEvent {
+    public val currentlyTyping: Set<String>
+}
+
+internal data class DefaultTypingEvent(override val currentlyTyping: Set<String>) : TypingEvent
 
 internal class DefaultTyping(
     private val room: DefaultRoom,
@@ -238,7 +242,7 @@ internal class DefaultTyping(
         if (lastTyping == currentlyTyping) return
         lastTyping = currentlyTyping
         listeners.forEach {
-            it.onEvent(TypingEvent(currentlyTyping))
+            it.onEvent(DefaultTypingEvent(currentlyTyping))
         }
     }
 }

--- a/chat-android/src/main/java/com/ably/chat/annotations/Annotations.kt
+++ b/chat-android/src/main/java/com/ably/chat/annotations/Annotations.kt
@@ -1,5 +1,3 @@
-@file:Suppress("Filename")
-
 package com.ably.chat.annotations
 
 /**
@@ -24,3 +22,10 @@ package com.ably.chat.annotations
     AnnotationTarget.PROPERTY_SETTER,
 )
 public annotation class ExperimentalChatApi
+
+/**
+ * A marker annotations for DSLs.
+ */
+@DslMarker
+@Target(AnnotationTarget.CLASS, AnnotationTarget.TYPEALIAS, AnnotationTarget.TYPE, AnnotationTarget.FUNCTION)
+public annotation class ChatDsl

--- a/chat-android/src/test/java/com/ably/chat/ChatApiTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/ChatApiTest.kt
@@ -16,7 +16,7 @@ class ChatApiTest {
 
     private val realtime = mockk<RealtimeClient>(relaxed = true)
     private val chatApi =
-        ChatApi(realtime, "clientId", parentLogger = EmptyLogger(LogContext(tag = "TEST")))
+        ChatApi(realtime, "clientId", parentLogger = EmptyLogger(DefaultLogContext(tag = "TEST")))
 
     /**
      * @nospec
@@ -45,7 +45,7 @@ class ChatApiTest {
 
         assertEquals(
             listOf(
-                Message(
+                DefaultMessage(
                     serial = "timeserial",
                     roomId = "roomId",
                     clientId = "clientId",
@@ -101,7 +101,7 @@ class ChatApiTest {
         val message = chatApi.sendMessage("roomId", SendMessageParams(text = "hello"))
 
         assertEquals(
-            Message(
+            DefaultMessage(
                 serial = "timeserial",
                 roomId = "roomId",
                 clientId = "clientId",

--- a/chat-android/src/test/java/com/ably/chat/ConnectionTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/ConnectionTest.kt
@@ -41,7 +41,7 @@ class ConnectionTest {
         pubSubConnection.reason = ErrorInfo("some error", 400)
         pubSubConnection.state = ConnectionState.disconnected
 
-        val connection = DefaultConnection(pubSubConnection, EmptyLogger(LogContext(tag = "TEST")))
+        val connection = DefaultConnection(pubSubConnection, EmptyLogger(DefaultLogContext(tag = "TEST")))
         assertEquals(ConnectionStatus.Disconnected, connection.status)
         assertEquals(pubSubConnection.reason, connection.error)
     }
@@ -51,7 +51,7 @@ class ConnectionTest {
      */
     @Test
     fun `status update events must contain the newly entered connection status`() = runTest {
-        val connection = DefaultConnection(pubSubConnection, EmptyLogger(LogContext(tag = "TEST")))
+        val connection = DefaultConnection(pubSubConnection, EmptyLogger(DefaultLogContext(tag = "TEST")))
         val deferredEvent = CompletableDeferred<ConnectionStatusChange>()
 
         connection.onStatusChange {
@@ -68,7 +68,7 @@ class ConnectionTest {
         )
 
         assertEquals(
-            ConnectionStatusChange(
+            DefaultConnectionStatusChange(
                 current = ConnectionStatus.Connecting,
                 previous = ConnectionStatus.Initialized,
                 retryIn = 0,
@@ -85,7 +85,7 @@ class ConnectionTest {
     fun `should wait 5 sec if the connection status transitions from CONNECTED to DISCONNECTED`() = runTest {
         val testScheduler = TestCoroutineScheduler()
         val dispatcher = StandardTestDispatcher(testScheduler)
-        val connection = DefaultConnection(pubSubConnection, EmptyLogger(LogContext(tag = "TEST")), dispatcher)
+        val connection = DefaultConnection(pubSubConnection, EmptyLogger(DefaultLogContext(tag = "TEST")), dispatcher)
 
         var status = ConnectionStatus.Initialized
 
@@ -118,7 +118,7 @@ class ConnectionTest {
     fun `should cancel the transient disconnect timer IF realtime connections status changes to CONNECTED`() = runTest {
         val testScheduler = TestCoroutineScheduler()
         val dispatcher = StandardTestDispatcher(testScheduler)
-        val connection = DefaultConnection(pubSubConnection, EmptyLogger(LogContext(tag = "TEST")), dispatcher)
+        val connection = DefaultConnection(pubSubConnection, EmptyLogger(DefaultLogContext(tag = "TEST")), dispatcher)
 
         var status = ConnectionStatus.Initialized
 

--- a/chat-android/src/test/java/com/ably/chat/MessagesTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/MessagesTest.kt
@@ -67,7 +67,7 @@ class MessagesTest {
         )
 
         assertEquals(
-            Message(
+            DefaultMessage(
                 serial = "abcdefghij@1672531200000-123",
                 clientId = "clientId",
                 roomId = "room1",
@@ -129,7 +129,7 @@ class MessagesTest {
 
         assertEquals(MessageEventType.Created, messageEvent.type)
         assertEquals(
-            Message(
+            DefaultMessage(
                 roomId = "room1",
                 createdAt = 1000L,
                 clientId = "clientId",

--- a/chat-android/src/test/java/com/ably/chat/OccupancyTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/OccupancyTest.kt
@@ -47,7 +47,7 @@ class OccupancyTest {
             roomId = "room1",
         )
 
-        assertEquals(OccupancyEvent(connections = 2, presenceMembers = 1), occupancy.get())
+        assertEquals(DefaultOccupancyEvent(connections = 2, presenceMembers = 1), occupancy.get())
     }
 
     /**
@@ -75,7 +75,7 @@ class OccupancyTest {
 
         pubSubMessageListenerSlot.captured.onMessage(occupancyEventMessage)
 
-        assertEquals(OccupancyEvent(connections = 2, presenceMembers = 1), deferredEvent.await())
+        assertEquals(DefaultOccupancyEvent(connections = 2, presenceMembers = 1), deferredEvent.await())
     }
 
     /**
@@ -109,7 +109,7 @@ class OccupancyTest {
         pubSubMessageListenerSlot.captured.onMessage(invalidOccupancyEvent)
         pubSubMessageListenerSlot.captured.onMessage(validOccupancyEvent)
 
-        assertEquals(OccupancyEvent(connections = 1, presenceMembers = 1), deferredEvent.await())
+        assertEquals(DefaultOccupancyEvent(connections = 1, presenceMembers = 1), deferredEvent.await())
     }
 
     /**
@@ -143,7 +143,7 @@ class OccupancyTest {
 
         pubSubMessageListenerSlot.captured.onMessage(fakeMessage)
 
-        assertEquals(OccupancyEvent(connections = 1, presenceMembers = 1), deferredEvent.await())
+        assertEquals(DefaultOccupancyEvent(connections = 1, presenceMembers = 1), deferredEvent.await())
     }
 
     @Test
@@ -165,7 +165,7 @@ class OccupancyTest {
         }
 
         occupancy.asFlow().test {
-            val event = OccupancyEvent(connections = 2, presenceMembers = 1)
+            val event = DefaultOccupancyEvent(connections = 2, presenceMembers = 1)
             callback.onEvent(event)
             assertEquals(event, awaitItem())
             cancel()

--- a/chat-android/src/test/java/com/ably/chat/PresenceTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/PresenceTest.kt
@@ -61,7 +61,7 @@ class PresenceTest {
         val presenceEvent = deferredValue.await()
 
         assertEquals(
-            PresenceEvent(
+            DefaultPresenceEvent(
                 action = PresenceMessage.Action.leave,
                 clientId = "client1",
                 timestamp = 100_000L,
@@ -98,7 +98,7 @@ class PresenceTest {
         val presenceEvent = deferredValue.await()
 
         assertEquals(
-            PresenceEvent(
+            DefaultPresenceEvent(
                 action = PresenceMessage.Action.leave,
                 clientId = "client1",
                 timestamp = 100_000L,
@@ -137,7 +137,7 @@ class PresenceTest {
         val presenceEvent = deferredValue.await()
 
         assertEquals(
-            PresenceEvent(
+            DefaultPresenceEvent(
                 action = PresenceMessage.Action.leave,
                 clientId = "client1",
                 timestamp = 100_000L,

--- a/chat-android/src/test/java/com/ably/chat/RoomOptionTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/RoomOptionTest.kt
@@ -7,24 +7,29 @@ class RoomOptionTest {
 
     @Test
     fun `default occupancy options should be equal`() {
-        assertEquals(OccupancyOptions(), OccupancyOptions())
-    }
-
-    @Test
-    fun `default room reaction options should be equal`() {
-        assertEquals(RoomReactionsOptions(), RoomReactionsOptions())
+        assertEquals(buildRoomOptions { occupancy() }.occupancy, buildRoomOptions { occupancy() }.occupancy)
     }
 
     @Test
     fun `default room options should be equal`() {
+        assertEquals(buildRoomOptions(), buildRoomOptions())
+    }
+
+    @Test
+    fun `custom typing options should be equal`() {
+        assertEquals(buildRoomOptions { typing { timeoutMs = 10 } }, buildRoomOptions { typing { timeoutMs = 10 } })
+    }
+
+    @Test
+    fun `all features room options should be equal`() {
         assertEquals(
-            RoomOptions.default,
-            RoomOptions(
-                typing = TypingOptions(),
-                presence = PresenceOptions(),
-                reactions = RoomReactionsOptions(),
-                occupancy = OccupancyOptions(),
-            ),
+            RoomOptions.AllFeaturesEnabled,
+            buildRoomOptions {
+                typing()
+                presence()
+                reactions()
+                occupancy()
+            },
         )
     }
 }

--- a/chat-android/src/test/java/com/ably/chat/RoomReactionsTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/RoomReactionsTest.kt
@@ -80,7 +80,7 @@ class RoomReactionsTest {
         val reaction = deferredValue.await()
 
         assertEquals(
-            Reaction(
+            DefaultReaction(
                 type = "like",
                 createdAt = 1000L,
                 clientId = "clientId",

--- a/chat-android/src/test/java/com/ably/chat/integration/ConnectionIntegrationTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/integration/ConnectionIntegrationTest.kt
@@ -2,6 +2,7 @@ package com.ably.chat.integration
 
 import com.ably.chat.ConnectionStatus
 import com.ably.chat.ConnectionStatusChange
+import com.ably.chat.DefaultConnectionStatusChange
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -18,7 +19,7 @@ class ConnectionIntegrationTest {
             if (it.current == ConnectionStatus.Connected) connectionStatusChange.complete(it)
         }
         assertEquals(
-            ConnectionStatusChange(
+            DefaultConnectionStatusChange(
                 current = ConnectionStatus.Connected,
                 previous = ConnectionStatus.Connecting,
                 error = null,

--- a/chat-android/src/test/java/com/ably/chat/integration/MessagesIntegrationTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/integration/MessagesIntegrationTest.kt
@@ -7,6 +7,7 @@ import com.ably.chat.MessageMetadata
 import com.ably.chat.RoomOptions
 import com.ably.chat.RoomStatus
 import com.ably.chat.assertWaiter
+import com.ably.chat.copy
 import io.ably.lib.realtime.channelOptions
 import io.ably.lib.types.MessageAction
 import java.util.UUID
@@ -50,7 +51,7 @@ class MessagesIntegrationTest {
         val chatClient = sandbox.createSandboxChatClient()
         val roomId = UUID.randomUUID().toString()
 
-        val room = chatClient.rooms.get(roomId, RoomOptions.default)
+        val room = chatClient.rooms.get(roomId, RoomOptions.AllFeaturesEnabled)
 
         room.attach()
 

--- a/chat-android/src/test/java/com/ably/chat/integration/OccupancyIntegrationTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/integration/OccupancyIntegrationTest.kt
@@ -1,8 +1,9 @@
 package com.ably.chat.integration
 
+import com.ably.chat.DefaultOccupancyEvent
 import com.ably.chat.OccupancyEvent
-import com.ably.chat.OccupancyOptions
-import com.ably.chat.RoomOptions
+import com.ably.chat.buildRoomOptions
+import com.ably.chat.occupancy
 import com.ably.chat.subscribeOnce
 import java.util.UUID
 import kotlinx.coroutines.CompletableDeferred
@@ -17,7 +18,7 @@ class OccupancyIntegrationTest {
     fun `should return occupancy for the client`() = runTest {
         val chatClient = sandbox.createSandboxChatClient("client1")
         val roomId = UUID.randomUUID().toString()
-        val roomOptions = RoomOptions(occupancy = OccupancyOptions())
+        val roomOptions = buildRoomOptions { occupancy() }
 
         val chatClientRoom = chatClient.rooms.get(roomId, roomOptions)
 
@@ -27,7 +28,7 @@ class OccupancyIntegrationTest {
         }
 
         chatClientRoom.attach()
-        assertEquals(OccupancyEvent(1, 0), firstOccupancyEvent.await())
+        assertEquals(DefaultOccupancyEvent(1, 0), firstOccupancyEvent.await())
     }
 
     companion object {

--- a/chat-android/src/test/java/com/ably/chat/integration/PresenceIntegrationTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/integration/PresenceIntegrationTest.kt
@@ -12,7 +12,7 @@ class PresenceIntegrationTest {
     @Test
     fun `should return empty list of presence members if nobody is entered`() = runTest {
         val chatClient = sandbox.createSandboxChatClient()
-        val room = chatClient.rooms.get(UUID.randomUUID().toString(), RoomOptions.default)
+        val room = chatClient.rooms.get(UUID.randomUUID().toString(), RoomOptions.AllFeaturesEnabled)
         room.attach()
         val members = room.presence.get()
         assertEquals(0, members.size)
@@ -21,7 +21,7 @@ class PresenceIntegrationTest {
     @Test
     fun `should return yourself as presence member after you entered`() = runTest {
         val chatClient = sandbox.createSandboxChatClient("sandbox-client")
-        val room = chatClient.rooms.get(UUID.randomUUID().toString(), RoomOptions.default)
+        val room = chatClient.rooms.get(UUID.randomUUID().toString(), RoomOptions.AllFeaturesEnabled)
         room.attach()
         room.presence.enter()
         val members = room.presence.get()

--- a/chat-android/src/test/java/com/ably/chat/integration/ReactionsIntegrationTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/integration/ReactionsIntegrationTest.kt
@@ -1,8 +1,8 @@
 package com.ably.chat.integration
 
 import com.ably.chat.Reaction
-import com.ably.chat.RoomOptions
-import com.ably.chat.RoomReactionsOptions
+import com.ably.chat.get
+import com.ably.chat.reactions
 import java.util.UUID
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.test.runTest
@@ -16,9 +16,8 @@ class ReactionsIntegrationTest {
     fun `should observe room reactions`() = runTest {
         val chatClient = sandbox.createSandboxChatClient()
         val roomId = UUID.randomUUID().toString()
-        val roomOptions = RoomOptions(reactions = RoomReactionsOptions())
 
-        val room = chatClient.rooms.get(roomId, roomOptions)
+        val room = chatClient.rooms.get(roomId) { reactions() }
         room.attach()
 
         val reactionEvent = CompletableDeferred<Reaction>()

--- a/chat-android/src/test/java/com/ably/chat/integration/Sandbox.kt
+++ b/chat-android/src/test/java/com/ably/chat/integration/Sandbox.kt
@@ -1,7 +1,7 @@
 package com.ably.chat.integration
 
-import com.ably.chat.ChatClientOptions
 import com.ably.chat.DefaultChatClient
+import com.ably.chat.buildChatClientOptions
 import com.ably.chat.serverError
 import com.google.gson.JsonElement
 import com.google.gson.JsonParser
@@ -42,7 +42,7 @@ private val client = HttpClient(CIO) {
 class Sandbox private constructor(val appId: String, val apiKey: String) {
     companion object {
         suspend fun createInstance(): Sandbox {
-            val response: HttpResponse = client.post("https://sandbox-rest.ably.io/apps") {
+            val response: HttpResponse = client.post("https://sandbox.realtime.ably-nonprod.net/apps") {
                 contentType(ContentType.Application.Json)
                 setBody(loadAppCreationRequestBody().toString())
             }
@@ -59,7 +59,7 @@ class Sandbox private constructor(val appId: String, val apiKey: String) {
 
 internal fun Sandbox.createSandboxChatClient(chatClientId: String = "sandbox-client"): DefaultChatClient {
     val realtime = createSandboxRealtime(chatClientId)
-    return DefaultChatClient(realtime, ChatClientOptions())
+    return DefaultChatClient(realtime, buildChatClientOptions())
 }
 
 internal fun Sandbox.createSandboxRealtime(chatClientId: String): AblyRealtime =
@@ -74,7 +74,7 @@ internal fun Sandbox.createSandboxRealtime(chatClientId: String): AblyRealtime =
 internal suspend fun Sandbox.getConnectedChatClient(chatClientId: String = "sandbox-client"): DefaultChatClient {
     val realtime = createSandboxRealtime(chatClientId)
     realtime.ensureConnected()
-    return DefaultChatClient(realtime, ChatClientOptions())
+    return DefaultChatClient(realtime, buildChatClientOptions())
 }
 
 private suspend fun AblyRealtime.ensureConnected() {

--- a/chat-android/src/test/java/com/ably/chat/integration/TypingIntegrationTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/integration/TypingIntegrationTest.kt
@@ -1,8 +1,8 @@
 package com.ably.chat.integration
 
-import com.ably.chat.RoomOptions
 import com.ably.chat.TypingEvent
-import com.ably.chat.TypingOptions
+import com.ably.chat.buildRoomOptions
+import com.ably.chat.typing
 import java.util.UUID
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.test.runTest
@@ -17,7 +17,7 @@ class TypingIntegrationTest {
         val chatClient1 = sandbox.createSandboxChatClient("client1")
         val chatClient2 = sandbox.createSandboxChatClient("client2")
         val roomId = UUID.randomUUID().toString()
-        val roomOptions = RoomOptions(typing = TypingOptions(timeoutMs = 10_000))
+        val roomOptions = buildRoomOptions { typing { timeoutMs = 10_000 } }
         val chatClient1Room = chatClient1.rooms.get(roomId, roomOptions)
         chatClient1Room.attach()
         val chatClient2Room = chatClient2.rooms.get(roomId, roomOptions)

--- a/chat-android/src/test/java/com/ably/chat/room/ConfigureRoomOptionsTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/room/ConfigureRoomOptionsTest.kt
@@ -4,7 +4,8 @@ import com.ably.chat.ChatApi
 import com.ably.chat.DefaultRoom
 import com.ably.chat.RoomOptions
 import com.ably.chat.RoomStatus
-import com.ably.chat.TypingOptions
+import com.ably.chat.buildRoomOptions
+import com.ably.chat.typing
 import io.ably.lib.types.AblyException
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
@@ -29,13 +30,13 @@ class ConfigureRoomOptionsTest {
         val chatApi = mockk<ChatApi>(relaxed = true)
 
         // Room success when positive typing timeout
-        val room = DefaultRoom("1234", RoomOptions(typing = TypingOptions(timeoutMs = 100)), mockRealtimeClient, chatApi, clientId, logger)
+        val room = DefaultRoom("1234", buildRoomOptions { typing { timeoutMs = 100 } }, mockRealtimeClient, chatApi, clientId, logger)
         Assert.assertNotNull(room)
         Assert.assertEquals(RoomStatus.Initialized, room.status)
 
         // Room failure when negative timeout
         val exception = assertThrows(AblyException::class.java) {
-            DefaultRoom("1234", RoomOptions(typing = TypingOptions(timeoutMs = -1)), mockRealtimeClient, chatApi, clientId, logger)
+            DefaultRoom("1234", buildRoomOptions { typing { timeoutMs = -1 } }, mockRealtimeClient, chatApi, clientId, logger)
         }
         Assert.assertEquals("Typing timeout must be greater than 0", exception.errorInfo.message)
         Assert.assertEquals(40_001, exception.errorInfo.code)
@@ -48,7 +49,7 @@ class ConfigureRoomOptionsTest {
         val chatApi = mockk<ChatApi>(relaxed = true)
 
         // Room only supports messages feature, since by default other features are turned off
-        val room = DefaultRoom("1234", RoomOptions(), mockRealtimeClient, chatApi, clientId, logger)
+        val room = DefaultRoom("1234", buildRoomOptions {}, mockRealtimeClient, chatApi, clientId, logger)
         Assert.assertNotNull(room)
         Assert.assertEquals(RoomStatus.Initialized, room.status)
 
@@ -85,7 +86,7 @@ class ConfigureRoomOptionsTest {
         Assert.assertEquals(400, exception.errorInfo.statusCode)
 
         // room with all features
-        val roomWithAllFeatures = DefaultRoom("1234", RoomOptions.default, mockRealtimeClient, chatApi, clientId, logger)
+        val roomWithAllFeatures = DefaultRoom("1234", RoomOptions.AllFeaturesEnabled, mockRealtimeClient, chatApi, clientId, logger)
         Assert.assertNotNull(roomWithAllFeatures.presence)
         Assert.assertNotNull(roomWithAllFeatures.reactions)
         Assert.assertNotNull(roomWithAllFeatures.typing)

--- a/chat-android/src/test/java/com/ably/chat/room/RoomEnsureAttachedTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/room/RoomEnsureAttachedTest.kt
@@ -3,12 +3,12 @@ package com.ably.chat.room
 import com.ably.chat.ChatApi
 import com.ably.chat.DefaultRoom
 import com.ably.chat.DefaultRoomLifecycle
+import com.ably.chat.DefaultRoomStatusChange
 import com.ably.chat.ErrorCode
 import com.ably.chat.HttpStatusCode
 import com.ably.chat.Room
 import com.ably.chat.RoomOptions
 import com.ably.chat.RoomStatus
-import com.ably.chat.RoomStatusChange
 import com.ably.chat.assertWaiter
 import com.ably.chat.setPrivateField
 import io.ably.lib.types.AblyException
@@ -37,7 +37,7 @@ class RoomEnsureAttachedTest {
 
     @Test
     fun `(CHA-PR3d, CHA-PR10d, CHA-PR6c, CHA-PR6c) When room is already ATTACHED, ensureAttached is a success`() = runTest {
-        val room = DefaultRoom(roomId, RoomOptions.default, mockRealtimeClient, chatApi, clientId, logger)
+        val room = DefaultRoom(roomId, RoomOptions.AllFeaturesEnabled, mockRealtimeClient, chatApi, clientId, logger)
         Assert.assertEquals(RoomStatus.Initialized, room.status)
 
         // Set room status to ATTACHED
@@ -51,7 +51,7 @@ class RoomEnsureAttachedTest {
     @Suppress("MaximumLineLength")
     @Test
     fun `(CHA-PR3h, CHA-PR10h, CHA-PR6h, CHA-T2g) When room is not ATTACHED or ATTACHING, ensureAttached throws error with code RoomInInvalidState`() = runTest {
-        val room = DefaultRoom(roomId, RoomOptions.default, mockRealtimeClient, chatApi, clientId, logger)
+        val room = DefaultRoom(roomId, RoomOptions.AllFeaturesEnabled, mockRealtimeClient, chatApi, clientId, logger)
         Assert.assertEquals(RoomStatus.Initialized, room.status)
 
         // List of room status other than ATTACHED/ATTACHING
@@ -82,7 +82,7 @@ class RoomEnsureAttachedTest {
 
     @Test
     fun `(CHA-RL9a) When room is ATTACHING, subscribe once for next room status`() = runTest {
-        val room = DefaultRoom(roomId, RoomOptions.default, mockRealtimeClient, chatApi, clientId, logger)
+        val room = DefaultRoom(roomId, RoomOptions.AllFeaturesEnabled, mockRealtimeClient, chatApi, clientId, logger)
         Assert.assertEquals(RoomStatus.Initialized, room.status)
 
         val roomLifecycleMock = spyk(DefaultRoomLifecycle(logger))
@@ -90,7 +90,7 @@ class RoomEnsureAttachedTest {
             roomLifecycleMock.onChangeOnce(any<Room.Listener>())
         } answers {
             val listener = firstArg<Room.Listener>()
-            listener.roomStatusChanged(RoomStatusChange(RoomStatus.Attached, RoomStatus.Attaching))
+            listener.roomStatusChanged(DefaultRoomStatusChange(RoomStatus.Attached, RoomStatus.Attaching))
         }
         room.setPrivateField("statusLifecycle", roomLifecycleMock)
 
@@ -107,7 +107,7 @@ class RoomEnsureAttachedTest {
 
     @Test
     fun `(CHA-RL9b) When room is ATTACHING, subscription is registered, ensureAttached is a success`() = runTest {
-        val room = DefaultRoom(roomId, RoomOptions.default, mockRealtimeClient, chatApi, clientId, logger)
+        val room = DefaultRoom(roomId, RoomOptions.AllFeaturesEnabled, mockRealtimeClient, chatApi, clientId, logger)
         Assert.assertEquals(RoomStatus.Initialized, room.status)
 
         // Set room status to ATTACHING
@@ -131,7 +131,7 @@ class RoomEnsureAttachedTest {
     @Suppress("MaximumLineLength")
     @Test
     fun `(CHA-RL9c) When room is ATTACHING and subscription is registered and fails, ensureAttached throws error with code RoomInInvalidState`() = runTest {
-        val room = DefaultRoom(roomId, RoomOptions.default, mockRealtimeClient, chatApi, clientId, logger)
+        val room = DefaultRoom(roomId, RoomOptions.AllFeaturesEnabled, mockRealtimeClient, chatApi, clientId, logger)
         Assert.assertEquals(RoomStatus.Initialized, room.status)
 
         // List of room status other than ATTACHED/ATTACHING

--- a/chat-android/src/test/java/com/ably/chat/room/RoomGetTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/room/RoomGetTest.kt
@@ -1,14 +1,16 @@
 package com.ably.chat.room
 
 import com.ably.chat.ChatApi
-import com.ably.chat.ChatClientOptions
 import com.ably.chat.DefaultRoom
 import com.ably.chat.DefaultRooms
-import com.ably.chat.PresenceOptions
 import com.ably.chat.RoomOptions
 import com.ably.chat.RoomStatus
-import com.ably.chat.TypingOptions
 import com.ably.chat.assertWaiter
+import com.ably.chat.buildChatClientOptions
+import com.ably.chat.buildRoomOptions
+import com.ably.chat.get
+import com.ably.chat.presence
+import com.ably.chat.typing
 import io.ably.lib.types.AblyException
 import io.mockk.coEvery
 import io.mockk.every
@@ -36,11 +38,11 @@ class RoomGetTest {
     fun `(CHA-RC1f) Requesting a room from the Chat Client return instance of a room with the provided id and options`() = runTest {
         val mockRealtimeClient = createMockRealtimeClient()
         val chatApi = mockk<ChatApi>(relaxed = true)
-        val rooms = DefaultRooms(mockRealtimeClient, chatApi, ChatClientOptions(), clientId, logger)
-        val room = rooms.get("1234", RoomOptions())
+        val rooms = DefaultRooms(mockRealtimeClient, chatApi, buildChatClientOptions(), clientId, logger)
+        val room = rooms.get("1234", buildRoomOptions())
         Assert.assertNotNull(room)
         Assert.assertEquals("1234", room.roomId)
-        Assert.assertEquals(RoomOptions(), room.options)
+        Assert.assertEquals(buildRoomOptions(), room.options)
     }
 
     @Suppress("MaximumLineLength")
@@ -48,17 +50,17 @@ class RoomGetTest {
     fun `(CHA-RC1f1) If the room id already exists, and newly requested with different options, then ErrorInfo with code 40000 is thrown`() = runTest {
         val mockRealtimeClient = createMockRealtimeClient()
         val chatApi = mockk<ChatApi>(relaxed = true)
-        val rooms = spyk(DefaultRooms(mockRealtimeClient, chatApi, ChatClientOptions(), clientId, logger), recordPrivateCalls = true)
+        val rooms = spyk(DefaultRooms(mockRealtimeClient, chatApi, buildChatClientOptions(), clientId, logger), recordPrivateCalls = true)
 
         // Create room with id "1234"
-        val room = rooms.get("1234", RoomOptions())
+        val room = rooms.get("1234", buildRoomOptions())
         Assert.assertEquals(1, rooms.RoomIdToRoom.size)
         Assert.assertEquals(room, rooms.RoomIdToRoom["1234"])
 
         // Throws exception for requesting room for different roomOptions
         val exception = assertThrows(AblyException::class.java) {
             runBlocking {
-                rooms.get("1234", RoomOptions(typing = TypingOptions()))
+                rooms.get("1234") { typing() }
             }
         }
         Assert.assertNotNull(exception)
@@ -70,47 +72,42 @@ class RoomGetTest {
     fun `(CHA-RC1f2) If the room id already exists, and newly requested with same options, then returns same room`() = runTest {
         val mockRealtimeClient = createMockRealtimeClient()
         val chatApi = mockk<ChatApi>(relaxed = true)
-        val rooms = spyk(DefaultRooms(mockRealtimeClient, chatApi, ChatClientOptions(), clientId, logger), recordPrivateCalls = true)
+        val rooms = spyk(DefaultRooms(mockRealtimeClient, chatApi, buildChatClientOptions(), clientId, logger), recordPrivateCalls = true)
 
-        val room1 = rooms.get("1234", RoomOptions())
+        val room1 = rooms.get("1234")
         Assert.assertEquals(1, rooms.RoomIdToRoom.size)
         Assert.assertEquals(room1, rooms.RoomIdToRoom["1234"])
 
-        val room2 = rooms.get("1234", RoomOptions())
+        val room2 = rooms.get("1234")
         Assert.assertEquals(1, rooms.RoomIdToRoom.size)
         Assert.assertEquals(room1, room2)
 
-        val room3 = rooms.get("5678", RoomOptions(typing = TypingOptions()))
+        val room3 = rooms.get("5678") { typing() }
         Assert.assertEquals(2, rooms.RoomIdToRoom.size)
         Assert.assertEquals(room3, rooms.RoomIdToRoom["5678"])
 
-        val room4 = rooms.get("5678", RoomOptions(typing = TypingOptions()))
+        val room4 = rooms.get("5678") { typing() }
         Assert.assertEquals(2, rooms.RoomIdToRoom.size)
         Assert.assertEquals(room3, room4)
 
-        val room5 = rooms.get(
-            "7890",
-            RoomOptions(
-                typing = TypingOptions(timeoutMs = 1500),
-                presence = PresenceOptions(
-                    enter = true,
-                    subscribe = false,
-                ),
-            ),
-        )
+        val room5 = rooms.get("7890") {
+            typing { timeoutMs = 1500 }
+            presence {
+                enter = true
+                subscribe = false
+            }
+        }
+
         Assert.assertEquals(3, rooms.RoomIdToRoom.size)
         Assert.assertEquals(room5, rooms.RoomIdToRoom["7890"])
 
-        val room6 = rooms.get(
-            "7890",
-            RoomOptions(
-                typing = TypingOptions(timeoutMs = 1500),
-                presence = PresenceOptions(
-                    enter = true,
-                    subscribe = false,
-                ),
-            ),
-        )
+        val room6 = rooms.get("7890") {
+            typing { timeoutMs = 1500 }
+            presence {
+                enter = true
+                subscribe = false
+            }
+        }
         Assert.assertEquals(3, rooms.RoomIdToRoom.size)
         Assert.assertEquals(room5, room6)
     }
@@ -120,7 +117,7 @@ class RoomGetTest {
     fun `(CHA-RC1f3) If no CHA-RC1g release operation is in progress, a new room instance shall be created, and added to the room map`() = runTest {
         val mockRealtimeClient = createMockRealtimeClient()
         val chatApi = mockk<ChatApi>(relaxed = true)
-        val rooms = spyk(DefaultRooms(mockRealtimeClient, chatApi, ChatClientOptions(), clientId, logger), recordPrivateCalls = true)
+        val rooms = spyk(DefaultRooms(mockRealtimeClient, chatApi, buildChatClientOptions(), clientId, logger), recordPrivateCalls = true)
         val roomId = "1234"
 
         // No release op. in progress
@@ -128,7 +125,7 @@ class RoomGetTest {
         Assert.assertNull(rooms.RoomReleaseDeferredMap[roomId])
 
         // Creates a new room and adds to the room map
-        val room = rooms.get("1234", RoomOptions())
+        val room = rooms.get("1234")
         Assert.assertEquals(1, rooms.RoomIdToRoom.size)
         Assert.assertEquals(room, rooms.RoomIdToRoom[roomId])
     }
@@ -140,10 +137,10 @@ class RoomGetTest {
         val roomId = "1234"
         val mockRealtimeClient = createMockRealtimeClient()
         val chatApi = mockk<ChatApi>(relaxed = true)
-        val rooms = spyk(DefaultRooms(mockRealtimeClient, chatApi, ChatClientOptions(), clientId, logger), recordPrivateCalls = true)
+        val rooms = spyk(DefaultRooms(mockRealtimeClient, chatApi, buildChatClientOptions(), clientId, logger), recordPrivateCalls = true)
 
         val defaultRoom = spyk(
-            DefaultRoom(roomId, RoomOptions.default, mockRealtimeClient, chatApi, clientId, logger),
+            DefaultRoom(roomId, RoomOptions.AllFeaturesEnabled, mockRealtimeClient, chatApi, clientId, logger),
             recordPrivateCalls = true,
         )
 
@@ -162,13 +159,13 @@ class RoomGetTest {
         } answers {
             var room = defaultRoom
             if (roomReleased.isClosedForSend) {
-                room = DefaultRoom(roomId, RoomOptions.default, mockRealtimeClient, chatApi, clientId, logger)
+                room = DefaultRoom(roomId, RoomOptions.AllFeaturesEnabled, mockRealtimeClient, chatApi, clientId, logger)
             }
             room
         }
 
         // Creates original room and adds to the room map
-        val originalRoom = rooms.get(roomId, RoomOptions())
+        val originalRoom = rooms.get(roomId)
         Assert.assertEquals(1, rooms.RoomIdToRoom.size)
         Assert.assertEquals(originalRoom, rooms.RoomIdToRoom[roomId])
 

--- a/chat-android/src/test/java/com/ably/chat/room/RoomReleaseTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/room/RoomReleaseTest.kt
@@ -1,7 +1,6 @@
 package com.ably.chat.room
 
 import com.ably.chat.ChatApi
-import com.ably.chat.ChatClientOptions
 import com.ably.chat.DefaultRoom
 import com.ably.chat.DefaultRooms
 import com.ably.chat.ErrorCode
@@ -10,6 +9,8 @@ import com.ably.chat.RoomOptions
 import com.ably.chat.RoomStatus
 import com.ably.chat.RoomStatusChange
 import com.ably.chat.assertWaiter
+import com.ably.chat.buildChatClientOptions
+import com.ably.chat.buildRoomOptions
 import io.ably.lib.types.AblyException
 import io.mockk.coEvery
 import io.mockk.coJustRun
@@ -43,10 +44,10 @@ class RoomReleaseTest {
         val roomId = "1234"
         val mockRealtimeClient = createMockRealtimeClient()
         val chatApi = mockk<ChatApi>(relaxed = true)
-        val rooms = spyk(DefaultRooms(mockRealtimeClient, chatApi, ChatClientOptions(), clientId, logger), recordPrivateCalls = true)
+        val rooms = spyk(DefaultRooms(mockRealtimeClient, chatApi, buildChatClientOptions(), clientId, logger), recordPrivateCalls = true)
 
         val defaultRoom = spyk(
-            DefaultRoom(roomId, RoomOptions.default, mockRealtimeClient, chatApi, clientId, logger),
+            DefaultRoom(roomId, RoomOptions.AllFeaturesEnabled, mockRealtimeClient, chatApi, clientId, logger),
             recordPrivateCalls = true,
         )
         coJustRun { defaultRoom.release() }
@@ -54,7 +55,7 @@ class RoomReleaseTest {
         every { rooms["makeRoom"](any<String>(), any<RoomOptions>()) } returns defaultRoom
 
         // Creates original room and adds to the room map
-        val room = rooms.get(roomId, RoomOptions())
+        val room = rooms.get(roomId, buildRoomOptions())
         Assert.assertEquals(1, rooms.RoomIdToRoom.size)
         Assert.assertEquals(room, rooms.RoomIdToRoom[roomId])
 
@@ -69,10 +70,10 @@ class RoomReleaseTest {
         val roomId = "1234"
         val mockRealtimeClient = createMockRealtimeClient()
         val chatApi = mockk<ChatApi>(relaxed = true)
-        val rooms = spyk(DefaultRooms(mockRealtimeClient, chatApi, ChatClientOptions(), clientId, logger), recordPrivateCalls = true)
+        val rooms = spyk(DefaultRooms(mockRealtimeClient, chatApi, buildChatClientOptions(), clientId, logger), recordPrivateCalls = true)
 
         val defaultRoom = spyk(
-            DefaultRoom(roomId, RoomOptions.default, mockRealtimeClient, chatApi, clientId, logger),
+            DefaultRoom(roomId, RoomOptions.AllFeaturesEnabled, mockRealtimeClient, chatApi, clientId, logger),
             recordPrivateCalls = true,
         )
 
@@ -91,7 +92,7 @@ class RoomReleaseTest {
         every { rooms["makeRoom"](any<String>(), any<RoomOptions>()) } returns defaultRoom
 
         // Creates original room and adds to the room map
-        val room = rooms.get(roomId, RoomOptions())
+        val room = rooms.get(roomId, buildRoomOptions())
         Assert.assertEquals(1, rooms.RoomIdToRoom.size)
         Assert.assertEquals(room, rooms.RoomIdToRoom[roomId])
 
@@ -111,7 +112,7 @@ class RoomReleaseTest {
         val roomId = "1234"
         val mockRealtimeClient = createMockRealtimeClient()
         val chatApi = mockk<ChatApi>(relaxed = true)
-        val rooms = spyk(DefaultRooms(mockRealtimeClient, chatApi, ChatClientOptions(), clientId, logger), recordPrivateCalls = true)
+        val rooms = spyk(DefaultRooms(mockRealtimeClient, chatApi, buildChatClientOptions(), clientId, logger), recordPrivateCalls = true)
 
         // No room exists
         Assert.assertEquals(0, rooms.RoomIdToRoom.size)
@@ -131,10 +132,10 @@ class RoomReleaseTest {
         val roomId = "1234"
         val mockRealtimeClient = createMockRealtimeClient()
         val chatApi = mockk<ChatApi>(relaxed = true)
-        val rooms = spyk(DefaultRooms(mockRealtimeClient, chatApi, ChatClientOptions(), clientId, logger), recordPrivateCalls = true)
+        val rooms = spyk(DefaultRooms(mockRealtimeClient, chatApi, buildChatClientOptions(), clientId, logger), recordPrivateCalls = true)
 
         val defaultRoom = spyk(
-            DefaultRoom(roomId, RoomOptions.default, mockRealtimeClient, chatApi, clientId, logger),
+            DefaultRoom(roomId, RoomOptions.AllFeaturesEnabled, mockRealtimeClient, chatApi, clientId, logger),
             recordPrivateCalls = true,
         )
         every { rooms["makeRoom"](any<String>(), any<RoomOptions>()) } returns defaultRoom
@@ -149,7 +150,7 @@ class RoomReleaseTest {
         }
 
         // Creates a room and adds to the room map
-        val room = rooms.get(roomId, RoomOptions())
+        val room = rooms.get(roomId, buildRoomOptions())
         Assert.assertEquals(1, rooms.RoomIdToRoom.size)
         Assert.assertEquals(room, rooms.RoomIdToRoom[roomId])
 
@@ -188,10 +189,10 @@ class RoomReleaseTest {
         val roomId = "1234"
         val mockRealtimeClient = createMockRealtimeClient()
         val chatApi = mockk<ChatApi>(relaxed = true)
-        val rooms = spyk(DefaultRooms(mockRealtimeClient, chatApi, ChatClientOptions(), clientId, logger), recordPrivateCalls = true)
+        val rooms = spyk(DefaultRooms(mockRealtimeClient, chatApi, buildChatClientOptions(), clientId, logger), recordPrivateCalls = true)
 
         val defaultRoom = spyk(
-            DefaultRoom(roomId, RoomOptions.default, mockRealtimeClient, chatApi, clientId, logger),
+            DefaultRoom(roomId, RoomOptions.AllFeaturesEnabled, mockRealtimeClient, chatApi, clientId, logger),
             recordPrivateCalls = true,
         )
 
@@ -210,13 +211,13 @@ class RoomReleaseTest {
         } answers {
             var room = defaultRoom
             if (roomReleased.isClosedForSend) {
-                room = DefaultRoom(roomId, RoomOptions.default, mockRealtimeClient, chatApi, clientId, logger)
+                room = DefaultRoom(roomId, RoomOptions.AllFeaturesEnabled, mockRealtimeClient, chatApi, clientId, logger)
             }
             room
         }
 
         // Creates original room and adds to the room map
-        val originalRoom = rooms.get(roomId, RoomOptions())
+        val originalRoom = rooms.get(roomId, buildRoomOptions())
         Assert.assertEquals(1, rooms.RoomIdToRoom.size)
         Assert.assertEquals(originalRoom, rooms.RoomIdToRoom[roomId])
 

--- a/chat-android/src/test/java/com/ably/chat/room/RoomTestHelpers.kt
+++ b/chat-android/src/test/java/com/ably/chat/room/RoomTestHelpers.kt
@@ -79,7 +79,7 @@ internal fun createMockRoom(
     chatApi: ChatApi = mockk<ChatApi>(relaxed = true),
     logger: Logger = createMockLogger(),
 ): DefaultRoom =
-    DefaultRoom(roomId, RoomOptions.default, realtimeClient, chatApi, clientId, logger)
+    DefaultRoom(roomId, RoomOptions.AllFeaturesEnabled, realtimeClient, chatApi, clientId, logger)
 
 // Rooms mocks
 val Rooms.RoomIdToRoom get() = getPrivateField<MutableMap<String, Room>>("roomIdToRoom")

--- a/chat-extensions-compose/src/test/kotlin/com/ably/chat/extensions/compose/ConnectionTest.kt
+++ b/chat-extensions-compose/src/test/kotlin/com/ably/chat/extensions/compose/ConnectionTest.kt
@@ -8,6 +8,7 @@ import com.ably.chat.ConnectionStatus
 import com.ably.chat.ConnectionStatusChange
 import com.ably.chat.Subscription
 import com.ably.chat.annotations.ExperimentalChatApi
+import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -50,4 +51,9 @@ class EmittingConnection(mock: Connection) : Connection by mock {
             it.connectionStatusChanged(event)
         }
     }
+}
+
+fun ConnectionStatusChange(current: ConnectionStatus, previous: ConnectionStatus): ConnectionStatusChange = mockk {
+    every { this@mockk.previous } returns previous
+    every { this@mockk.current } returns current
 }

--- a/chat-extensions-compose/src/test/kotlin/com/ably/chat/extensions/compose/OccupancyTest.kt
+++ b/chat-extensions-compose/src/test/kotlin/com/ably/chat/extensions/compose/OccupancyTest.kt
@@ -31,12 +31,12 @@ class OccupancyTest {
         moleculeFlow(RecompositionMode.Immediate) {
             room.collectAsOccupancy()
         }.test {
-            assertEquals(CurrentOccupancy(0, 0), awaitItem())
-            assertEquals(CurrentOccupancy(1, 0), awaitItem())
+            assertEquals(DefaultCurrentOccupancy(0, 0), awaitItem())
+            assertEquals(DefaultCurrentOccupancy(1, 0), awaitItem())
             occupancy.emit(OccupancyEvent(1, 1))
-            assertEquals(CurrentOccupancy(1, 1), awaitItem())
+            assertEquals(DefaultCurrentOccupancy(1, 1), awaitItem())
             occupancy.emit(OccupancyEvent(2, 1))
-            assertEquals(CurrentOccupancy(2, 1), awaitItem())
+            assertEquals(DefaultCurrentOccupancy(2, 1), awaitItem())
         }
     }
 
@@ -47,12 +47,12 @@ class OccupancyTest {
         moleculeFlow(RecompositionMode.Immediate) {
             room.collectAsOccupancy()
         }.test {
-            assertEquals(CurrentOccupancy(), awaitItem())
+            assertEquals(DefaultCurrentOccupancy(), awaitItem())
             occupancy.emit(OccupancyEvent(1, 0))
-            assertEquals(CurrentOccupancy(1, 0), awaitItem())
+            assertEquals(DefaultCurrentOccupancy(1, 0), awaitItem())
             occupancy.resume()
             occupancy.emit(OccupancyEvent(2, 1))
-            assertEquals(CurrentOccupancy(2, 1), awaitItem())
+            assertEquals(DefaultCurrentOccupancy(2, 1), awaitItem())
         }
     }
 }
@@ -87,4 +87,9 @@ class EmittingOccupancy(val mock: Occupancy) : Occupancy by mock {
             it.onEvent(event)
         }
     }
+}
+
+fun OccupancyEvent(connections: Int, presenceMembers: Int): OccupancyEvent = mockk {
+    every { this@mockk.connections } returns connections
+    every { this@mockk.presenceMembers } returns presenceMembers
 }

--- a/chat-extensions-compose/src/test/kotlin/com/ably/chat/extensions/compose/PresenceTest.kt
+++ b/chat-extensions-compose/src/test/kotlin/com/ably/chat/extensions/compose/PresenceTest.kt
@@ -4,6 +4,7 @@ import app.cash.molecule.RecompositionMode
 import app.cash.molecule.moleculeFlow
 import app.cash.turbine.test
 import com.ably.chat.Presence
+import com.ably.chat.PresenceData
 import com.ably.chat.PresenceEvent
 import com.ably.chat.PresenceMember
 import com.ably.chat.Room
@@ -18,6 +19,7 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Test
 
 @OptIn(ExperimentalChatApi::class)
@@ -42,18 +44,14 @@ class PresenceTest {
                     timestamp = 0L,
                 ),
             )
-            assertEquals(
-                listOf(
-                    PresenceMember(
-                        clientId = "client1",
-                        action = PresenceMessage.Action.enter,
-                        data = null,
-                        extras = emptyMap(),
-                        updatedAt = 0L,
-                    ),
-                ),
-                awaitItem(),
-            )
+            var members = awaitItem()
+            assertEquals(1, members.size)
+            assertEquals("client1", members.first().clientId)
+            assertEquals(PresenceMessage.Action.enter, members.first().action)
+            assertNull(members.first().data)
+            assertEquals(JsonObject(), members.first().extras)
+            assertEquals(0, members.first().updatedAt)
+
             presence.emit(
                 PresenceEvent(
                     action = PresenceMessage.Action.update,
@@ -62,18 +60,13 @@ class PresenceTest {
                     timestamp = 1L,
                 ),
             )
-            assertEquals(
-                listOf(
-                    PresenceMember(
-                        clientId = "client1",
-                        action = PresenceMessage.Action.update,
-                        data = JsonObject(),
-                        extras = emptyMap(),
-                        updatedAt = 1L,
-                    ),
-                ),
-                awaitItem(),
-            )
+            members = awaitItem()
+            assertEquals(1, members.size)
+            assertEquals("client1", members.first().clientId)
+            assertEquals(PresenceMessage.Action.update, members.first().action)
+            assertEquals(JsonObject(), members.first().data)
+            assertEquals(JsonObject(), members.first().extras)
+            assertEquals(1, members.first().updatedAt)
         }
     }
 
@@ -101,18 +94,13 @@ class PresenceTest {
                 ),
             )
             presence.resume()
-            assertEquals(
-                listOf(
-                    PresenceMember(
-                        clientId = "client1",
-                        action = PresenceMessage.Action.update,
-                        data = JsonObject(),
-                        extras = emptyMap(),
-                        updatedAt = 1L,
-                    ),
-                ),
-                awaitItem(),
-            )
+            val members = awaitItem()
+            assertEquals(1, members.size)
+            assertEquals("client1", members.first().clientId)
+            assertEquals(PresenceMessage.Action.update, members.first().action)
+            assertEquals(JsonObject(), members.first().data)
+            assertEquals(JsonObject(), members.first().extras)
+            assertEquals(1, members.first().updatedAt)
         }
     }
 }
@@ -146,11 +134,32 @@ class EmittingPresence(val mock: Presence) : Presence by mock {
             clientId = event.clientId,
             action = event.action,
             data = event.data,
-            extras = emptyMap(),
+            extras = JsonObject(),
             updatedAt = event.timestamp,
         )
         listeners.forEach {
             it.onEvent(event)
         }
     }
+}
+
+fun PresenceEvent(action: PresenceMessage.Action, clientId: String, data: PresenceData?, timestamp: Long): PresenceEvent = mockk {
+    every { this@mockk.action } returns action
+    every { this@mockk.clientId } returns clientId
+    every { this@mockk.data } returns data
+    every { this@mockk.timestamp } returns timestamp
+}
+
+fun PresenceMember(
+    clientId: String,
+    data: PresenceData?,
+    action: PresenceMessage.Action,
+    updatedAt: Long,
+    extras: JsonObject,
+): PresenceMember = mockk {
+    every { this@mockk.clientId } returns clientId
+    every { this@mockk.data } returns data
+    every { this@mockk.action } returns action
+    every { this@mockk.updatedAt } returns updatedAt
+    every { this@mockk.extras } returns extras
 }

--- a/chat-extensions-compose/src/test/kotlin/com/ably/chat/extensions/compose/RoomTest.kt
+++ b/chat-extensions-compose/src/test/kotlin/com/ably/chat/extensions/compose/RoomTest.kt
@@ -8,6 +8,7 @@ import com.ably.chat.RoomStatus
 import com.ably.chat.RoomStatusChange
 import com.ably.chat.Subscription
 import com.ably.chat.annotations.ExperimentalChatApi
+import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -50,4 +51,9 @@ class EmittingRoom(mock: Room) : Room by mock {
             it.roomStatusChanged(event)
         }
     }
+}
+
+fun RoomStatusChange(current: RoomStatus, previous: RoomStatus): RoomStatusChange = mockk {
+    every { this@mockk.current } returns current
+    every { this@mockk.previous } returns previous
 }

--- a/chat-extensions-compose/src/test/kotlin/com/ably/chat/extensions/compose/TypingTest.kt
+++ b/chat-extensions-compose/src/test/kotlin/com/ably/chat/extensions/compose/TypingTest.kt
@@ -53,3 +53,7 @@ class EmittingTyping(mock: Typing) : Typing by mock {
         }
     }
 }
+
+fun TypingEvent(currentlyTyping: Set<String>): TypingEvent = mockk {
+    every { this@mockk.currentlyTyping } returns currentlyTyping
+}

--- a/detekt.yml
+++ b/detekt.yml
@@ -546,6 +546,12 @@ formatting:
     maxLineLength: 140
     indentSize: 4
 
+libraries:
+  active: true
+  ForbiddenPublicDataClass:
+    active: true
+    excludes: [ '**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**' ]
+
 naming:
   active: true
   BooleanPropertyNaming:

--- a/example/src/main/java/com/ably/chat/example/MainActivity.kt
+++ b/example/src/main/java/com/ably/chat/example/MainActivity.kt
@@ -44,22 +44,20 @@ import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.ably.chat.ChatClient
-import com.ably.chat.ChatClientOptions
 import com.ably.chat.LogLevel
 import com.ably.chat.Message
-import com.ably.chat.MessageMetadata
 import com.ably.chat.Reaction
 import com.ably.chat.Room
 import com.ably.chat.RoomOptions
 import com.ably.chat.annotations.ExperimentalChatApi
 import com.ably.chat.asFlow
+import com.ably.chat.copy
 import com.ably.chat.example.ui.PresencePopup
 import com.ably.chat.example.ui.theme.AblyChatExampleTheme
 import com.ably.chat.extensions.compose.collectAsCurrentlyTyping
 import com.ably.chat.extensions.compose.collectAsPagingMessagesState
 import io.ably.lib.realtime.AblyRealtime
 import io.ably.lib.types.ClientOptions
-import io.ably.lib.types.MessageAction
 import java.util.UUID
 import kotlinx.coroutines.launch
 
@@ -77,7 +75,7 @@ class MainActivity : ComponentActivity() {
             },
         )
 
-        val chatClient = ChatClient(realtimeClient, ChatClientOptions(logLevel = LogLevel.Trace))
+        val chatClient = ChatClient(realtimeClient) { logLevel = LogLevel.Trace }
 
         enableEdgeToEdge()
         setContent {
@@ -98,7 +96,7 @@ fun App(chatClient: ChatClient) {
     LaunchedEffect(Unit) {
         val chatRoom = chatClient.rooms.get(
             Settings.ROOM_ID,
-            RoomOptions.default,
+            RoomOptions.AllFeaturesEnabled,
         )
         chatRoom.attach()
         room = chatRoom
@@ -362,27 +360,6 @@ fun ChatInputField(
                 Text("Send")
             }
         }
-    }
-}
-
-@Preview
-@Composable
-fun MessageBubblePreview() {
-    AblyChatExampleTheme {
-        MessageBubble(
-            message = Message(
-                text = "Hello World!",
-                serial = "fake",
-                roomId = "roomId",
-                clientId = "clientId",
-                createdAt = System.currentTimeMillis(),
-                metadata = MessageMetadata(),
-                headers = mapOf(),
-                action = MessageAction.MESSAGE_CREATE,
-                version = "fake",
-                timestamp = System.currentTimeMillis(),
-            ),
-        )
     }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,6 +27,7 @@ turbine = "1.2.0"
 [libraries]
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 detekt-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detekt" }
+detekt-rules-libraries = { module = "io.gitlab.arturbosch.detekt:detekt-rules-libraries", version.ref = "detekt" }
 ably-android = { module = "io.ably:ably-android", version.ref = "ably" }
 ably-pubsub-adapter = { module = "io.ably:pubsub-adapter", version.ref = "ably" }
 androidx-test-core = { module = "androidx.test:core", version.ref = "androidx-test" }


### PR DESCRIPTION
Data classes are not recommended for public APIs due to potential backward compatibility issues. See [Kotlin API Guidelines](https://kotlinlang.org/docs/api-guidelines-backward-compatibility.html#avoid-using-data-classes-in-your-api) for more details


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a type-safe, builder-pattern based configuration for chat clients and rooms, enabling more flexible customization of logging, presence, typing, reactions, and occupancy.
  - Added a new DSL annotation to streamline chat configuration setups.

- **Refactor**
  - Consolidated core chat interfaces for messaging, connection, and event handling to deliver a more consistent developer experience.
  - Revised room and client option APIs for greater clarity and future extensibility.
  - Enhanced the structure of occupancy and presence events by transitioning to interface-based designs.

- **Chores**
  - Updated static analysis dependencies and quality rules to further improve overall code robustness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->