### PR TITLE
[ECO-5242][CHADR-093] Implement ephemeral typing

### DIFF
--- a/chat-android/src/main/java/com/ably/chat/EventTypes.kt
+++ b/chat-android/src/main/java/com/ably/chat/EventTypes.kt
@@ -73,9 +73,19 @@ public enum class PresenceEventType(public val eventName: String) {
     Present("present"),
 }
 
+/**
+ * Enum representing typing events.
+ */
 public enum class TypingEventType(public val eventName: String) {
-    /** The set of currently typing users has changed. */
-    Changed("typing.changed"),
+    /**
+     * Event triggered when a user starts typing.
+     */
+    Started("typing.started"),
+
+    /**
+     * Event triggered when a user stops typing.
+     */
+    Stopped("typing.stopped"),
 }
 
 /**

--- a/chat-android/src/main/java/com/ably/chat/Typing.kt
+++ b/chat-android/src/main/java/com/ably/chat/Typing.kt
@@ -2,39 +2,26 @@ package com.ably.chat
 
 import com.ably.annotations.InternalAPI
 import com.ably.pubsub.RealtimeChannel
+import com.google.gson.JsonObject
 import io.ably.lib.realtime.Channel
-import io.ably.lib.realtime.Presence.PresenceListener
 import io.ably.lib.types.AblyException
 import io.ably.lib.types.ErrorInfo
+import io.ably.lib.types.Message
+import io.ably.lib.types.MessageExtras
 import java.util.concurrent.CopyOnWriteArrayList
-import kotlin.math.min
-import kotlin.math.pow
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.TimeSource
+import kotlin.time.TimeSource.Monotonic.ValueTimeMark
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.launch
-
-/**
- * base retry interval, we double it each time
- */
-internal const val PRESENCE_GET_RETRY_INTERVAL_MS: Long = 1500
-
-/**
- * max retry interval
- */
-internal const val PRESENCE_GET_RETRY_MAX_INTERVAL_MS: Long = 30_000
-
-/**
- *  max num of retries
- */
-internal const val PRESENCE_GET_MAX_RETRIES = 5
 
 /**
  * This interface is used to interact with typing in a chat room including subscribing to typing events and
@@ -43,9 +30,10 @@ internal const val PRESENCE_GET_MAX_RETRIES = 5
  * Get an instance via [Room.typing].
  */
 public interface Typing : EmitsDiscontinuities {
+
     /**
-     * Get the name of the realtime channel underpinning typing events.
-     * @returns The name of the realtime channel.
+     * Get the Ably realtime channel underpinning typing events.
+     * @returns The Ably realtime channel.
      */
     public val channel: Channel
 
@@ -53,25 +41,53 @@ public interface Typing : EmitsDiscontinuities {
      * Subscribe a given listener to all typing events from users in the chat room.
      *
      * @param listener A listener to be called when the typing state of a user in the room changes.
+     * @returns A response object that allows you to control the subscription to typing events.
      */
     public fun subscribe(listener: Listener): Subscription
 
     /**
-     * Get the current typers, a set of clientIds.
+     * Current typing members.
      * @return set of clientIds that are currently typing.
      */
-    public suspend fun get(): Set<String>
+    public fun get(): Set<String>
 
     /**
-     * Start indicates that the current user is typing. This will emit a typingStarted event to inform listening clients and begin a timer,
-     * once the timer expires, a typingStopped event will be emitted. The timeout is configurable through the typingTimeoutMs parameter.
-     * If the current user is already typing, it will reset the timer and being counting down again without emitting a new event.
+     * This will send a `typing.started` event to the server.
+     * Events are throttled according to the `heartbeatThrottleMs` room option.
+     * If an event has been sent within the interval, this operation is no-op.
+     *
+     *
+     * Calls to `keystroke()` and `stop()` are serialized and will always be performed in the correct order.
+     * - For example, if multiple `keystroke()` calls are made in quick succession before the first `keystroke()` call has
+     *   sent a `typing.started` event to the server, followed by one `stop()` call, the `stop()` call will execute
+     *   as soon as the first `keystroke()` call completes.
+     *   All intermediate `keystroke()` calls will be treated as no-ops.
+     * - The most recent operation (`keystroke()` or `stop()`) will always determine the final state, ensuring operations
+     *   resolve to a consistent and correct state.
+     *
+     * @returns when there is a success or throws AblyException upon its failure.
+     * @throws AblyException if the `RoomStatus` is not either `Attached` or `Attaching`.
+     * @throws AblyException if the operation fails to send the event to the server.
+     * @throws AblyException if there is a problem acquiring the mutex that controls serialization.
      */
-    public suspend fun start()
+    public suspend fun keystroke()
 
     /**
-     * Stop indicates that the current user has stopped typing. This will emit a typingStopped event to inform listening clients,
-     * and immediately clear the typing timeout timer.
+     * This will send a `typing.stopped` event to the server.
+     * If the user was not currently typing, this operation is no-op.
+     *
+     * Calls to `keystroke()` and `stop()` are serialized and will always be performed in the correct order.
+     * - For example, if multiple `keystroke()` calls are made in quick succession before the first `keystroke()` call has
+     *   sent a `typing.started` event to the server, followed by one `stop()` call, the `stop()` call will execute
+     *   as soon as the first `keystroke()` call completes.
+     *   All intermediate `keystroke()` calls will be treated as no-ops.
+     * - The most recent operation (`keystroke()` or `stop()`) will always determine the final state, ensuring operations
+     *   resolve to a consistent and correct state.
+     *
+     * @returns when there is a success or throws AblyException upon its failure.
+     * @throws AblyException if the `RoomStatus` is not either `Attached` or `Attaching`.
+     * @throws AblyException if the operation fails to send the event to the server.
+     * @throws AblyException if there is a problem acquiring the mutex that controls serialization.
      */
     public suspend fun stop()
 
@@ -98,10 +114,38 @@ public fun Typing.asFlow(): Flow<TypingEvent> = transformCallbackAsFlow {
  * Represents a typing event.
  */
 public interface TypingEvent {
+    /**
+     * The set of user clientIds that are currently typing.
+     */
     public val currentlyTyping: Set<String>
+
+    /**
+     * The change that caused this event.
+     */
+    public val change: Change
+
+    public interface Change {
+        /**
+         * The client ID of the user who started or stopped typing.
+         */
+        public val clientId: String
+
+        /**
+         * The type of typing event.
+         */
+        public val type: TypingEventType
+    }
 }
 
-internal data class DefaultTypingEvent(override val currentlyTyping: Set<String>) : TypingEvent
+internal data class DefaultTypingEvent(
+    override val currentlyTyping: Set<String>,
+    override val change: DefaultTypingEventChange,
+) : TypingEvent
+
+internal data class DefaultTypingEventChange(
+    override val type: TypingEventType,
+    override val clientId: String,
+) : TypingEvent.Change
 
 internal class DefaultTyping(
     private val room: DefaultRoom,
@@ -119,130 +163,203 @@ internal class DefaultTyping(
 
     private val typingScope = CoroutineScope(dispatcher.limitedParallelism(1) + SupervisorJob())
 
-    private val eventBus = MutableSharedFlow<Unit>(
-        extraBufferCapacity = 1,
-        onBufferOverflow = BufferOverflow.DROP_OLDEST,
-    )
+    private var typingHeartbeatStarted: ValueTimeMark? = null
 
     override val channelWrapper: RealtimeChannel = room.realtimeClient.channels.get(typingIndicatorsChannelName, ChatChannelOptions())
 
     @OptIn(InternalAPI::class)
     override val channel: Channel = channelWrapper.javaChannel // CHA-RC2f
 
-    private var typingJob: Job? = null
-
     private val listeners: MutableList<Typing.Listener> = CopyOnWriteArrayList()
 
-    private var lastTyping: Set<String> = setOf()
+    private var currentlyTypingMembers: MutableSet<String> = mutableSetOf()
 
-    private var presenceSubscription: Subscription
+    private var typingEventPubSubSubscription: Subscription
 
+    /**
+     * A mutable map of clientId to TimedTypingStopEvent job.
+     * Each received typing start event is capable of timed death after a certain period (heartbeatThrottle + timeout).
+     */
+    private val typingStartEventPrunerJobs = mutableMapOf<String, Job>()
+
+    /**
+     * Defines how often a typing.started heartbeat can be sent (in milliseconds).
+     * This does not prevent a client from sending an typing.stopped heartbeat—doing so resets the interval timer
+     * and allows another typing.started to be sent.
+     * Spec: CHA-T10
+     */
+    private val heartbeatThrottle: Duration = room.options.typing?.heartbeatThrottle ?: throw AblyException.fromErrorInfo(
+        ErrorInfo(
+            "Typing options hasn't been initialized",
+            ErrorCode.BadRequest.code,
+        ),
+    )
+
+    /**
+     * Defines how long to wait before marking a user as stopped typing.
+     * For example, if the last typing.started heartbeat was received 10s ago, the system will wait an additional 2s before declaring
+     * the client as no longer typing.
+     * @defaultValue 2 seconds
+     * Spec: CHA-T10a
+     */
+    private val timeout: Duration = 2.seconds
+
+    /**
+     * Time source for measuring elapsed time.
+     */
+    private val timeSource = TimeSource.Monotonic
+
+    /**
+     * Spec: CHA-TM14 - Only latest job is processed, old queued jobs are dropped/ignored.
+     */
+    private val latestJobExecutor = LatestJobExecutor()
+
+    /**
+     * Spec: CHA-T13
+     */
     init {
-        typingScope.launch {
-            eventBus.collect {
-                processEvent()
+        // Process received typing events
+        val typingListener = PubSubMessageListener { msg ->
+            val typingEventType = TypingEventType.entries.first { it.eventName == msg.name }
+            // CHA-T13a
+            if (msg.clientId == null || msg.clientId.isEmpty()) {
+                logger.error("unable to handle typing event; no clientId", context = mapOf("message" to msg.toString()))
+                return@PubSubMessageListener
+            }
+            typingScope.launch {
+                processReceivedTypingEvents(typingEventType, msg.clientId)
             }
         }
-
-        val presenceListener = PresenceListener {
-            if (it.clientId == null) {
-                logger.error("unable to handle typing event; no clientId", context = mapOf("member" to it.toString()))
-            } else {
-                eventBus.tryEmit(Unit)
-            }
-        }
-
-        presenceSubscription = channelWrapper.presence.subscribe(presenceListener).asChatSubscription()
+        val typingEvents = listOf(TypingEventType.Started.eventName, TypingEventType.Stopped.eventName)
+        typingEventPubSubSubscription = channelWrapper.subscribe(typingEvents, typingListener).asChatSubscription()
     }
 
+    /**
+     * Spec: CHA-T6a
+     */
     override fun subscribe(listener: Typing.Listener): Subscription {
         logger.trace("DefaultTyping.subscribe()")
         listeners.add(listener)
+        // CHA-T6b
         return Subscription {
             logger.trace("DefaultTyping.unsubscribe()")
             listeners.remove(listener)
         }
     }
 
-    override suspend fun get(): Set<String> {
+    /**
+     * Spec: CHA-T9
+     */
+    override fun get(): Set<String> {
         logger.trace("DefaultTyping.get()")
-        room.ensureAttached(logger) // CHA-T2d, CHA-T2c, CHA-T2g
-        return channelWrapper.presence.getCoroutine().map { it.clientId }.toSet()
+        return currentlyTypingMembers.toSet()
     }
 
-    override suspend fun start() {
-        logger.trace("DefaultTyping.start()")
-
-        typingScope.launch {
-            // If the user is already typing, reset the timer
-            if (typingJob != null) {
-                logger.debug("DefaultTyping.start(); already typing, resetting timer")
-                typingJob?.cancel()
-                startTypingTimer()
-            } else {
-                startTypingTimer()
-                room.ensureAttached(logger) // CHA-T4a1, CHA-T4a3, CHA-T4a4
-                channelWrapper.presence.enterClientCoroutine(room.clientId)
+    /**
+     * Spec: CHA-T4, CHA-T14
+     */
+    override suspend fun keystroke() {
+        latestJobExecutor.run {
+            // CHA-T4c - If heartbeat is active, it's a no-op
+            typingHeartbeatStarted?.let {
+                if (it.elapsedNow() < heartbeatThrottle) {
+                    logger.trace("DefaultTyping.sendSelfTypingEvent(); typingHeartbeat is not elapsed, so it's a no-op")
+                    return@run
+                }
             }
-        }.join()
+            // send typing.start event
+            room.ensureAttached(logger) // CHA-T4a1, CHA-T4a3, CHA-T4a4, CHA-T4d
+            sendTyping(TypingEventType.Started) // CHA-T4a3
+            typingHeartbeatStarted = timeSource.markNow() // CHA-T4a4
+        }
     }
 
+    /**
+     * Spec: CHA-T5, CHA-T14
+     */
     override suspend fun stop() {
-        logger.trace("DefaultTyping.stop()")
-        typingScope.launch {
-            typingJob?.cancel()
-            typingJob = null
+        latestJobExecutor.run {
+            // CHA-T5a - If heartbeat is off, it's a no-op
+            if (typingHeartbeatStarted == null) {
+                logger.trace("DefaultTyping.sendSelfTypingEvent(); typing is not started or already stopped, so it's a no-op")
+                return@run
+            }
+            // CHA-T5a - If heartbeat is expired, it's a no-op
+            typingHeartbeatStarted?.let {
+                if (it.elapsedNow() > heartbeatThrottle) {
+                    logger.trace("DefaultTyping.sendSelfTypingEvent(); typingHeartbeat is elapsed, so it's a no-op")
+                    return@run
+                }
+            }
+            // send typing.stop event
             room.ensureAttached(logger) // CHA-T5e, CHA-T5c, CHA-T5d
-            channelWrapper.presence.leaveClientCoroutine(room.clientId)
-        }.join()
+            sendTyping(TypingEventType.Stopped) // CHA-T5d
+            typingHeartbeatStarted = null // CHA-T5e
+        }
+    }
+
+    private suspend fun sendTyping(eventType: TypingEventType) {
+        logger.trace("DefaultTyping.sendTyping()")
+        val msgExtras = JsonObject().apply {
+            addProperty("ephemeral", true)
+        }
+        try {
+            logger.debug("DefaultTyping.sendTyping(); sending typing event $eventType")
+            channelWrapper.publishCoroutine(Message(eventType.eventName, "", MessageExtras(msgExtras)))
+        } catch (e: Exception) {
+            logger.error("DefaultTyping.sendTyping(); failed to publish typing event", e)
+            throw e
+        }
     }
 
     override fun release() {
-        presenceSubscription.unsubscribe()
+        typingEventPubSubSubscription.unsubscribe()
         typingScope.cancel()
         room.realtimeClient.channels.release(channelWrapper.name)
     }
 
-    private fun startTypingTimer() {
-        val timeout = room.options.typing?.timeoutMs ?: throw AblyException.fromErrorInfo(
-            ErrorInfo(
-                "Typing options hasn't been initialized",
-                ErrorCode.BadRequest.code,
-            ),
-        )
-        logger.trace("DefaultTyping.startTypingTimer()")
-        typingJob = typingScope.launch {
-            delay(timeout)
-            logger.debug("DefaultTyping.startTypingTimer(); timeout expired")
-            stop()
-        }
-    }
-
-    private suspend fun processEvent() {
-        var numRetries = 0
-        while (numRetries <= PRESENCE_GET_MAX_RETRIES) {
-            try {
-                val currentlyTyping = get()
-                emit(currentlyTyping)
-                return // Exit if successful
-            } catch (e: Exception) {
-                numRetries++
-                val delayDuration = min(
-                    PRESENCE_GET_RETRY_MAX_INTERVAL_MS,
-                    PRESENCE_GET_RETRY_INTERVAL_MS * 2.0.pow(numRetries).toLong(),
-                )
-                logger.debug("Retrying in $delayDuration ms... (Attempt $numRetries of $PRESENCE_GET_MAX_RETRIES)", e)
-                delay(delayDuration)
+    /**
+     * Processes a typing event by updating the set of currently typing members and scheduling or canceling
+     * the corresponding timed event pruner jobs.
+     * Emits the typing event to all listeners.
+     *
+     * @param eventType The type of typing event (started or stopped).
+     * @param clientId The ID of the user who triggered the typing event.
+     * Spec: CHA-T13
+     */
+    private fun processReceivedTypingEvents(eventType: TypingEventType, clientId: String) {
+        when (eventType) {
+            TypingEventType.Started -> { // CHA-T13b1
+                currentlyTypingMembers.add(clientId)
+                // CHA-T13b2 - Cancel the current self stopping event and replace with new one
+                typingStartEventPrunerJobs[clientId]?.cancel()
+                // CHA-T10a1, CHA-T13b3 - If a typing.start not received within this period, the client shall assume that the user has stopped typing
+                val timedTypingStopEvent: Job = typingScope.launch {
+                    val typingEventWaitingTimeout = heartbeatThrottle + timeout
+                    delay(typingEventWaitingTimeout)
+                    // typingEventWaitingTimeout elapsed, so remove given clientId and emit stop event
+                    currentlyTypingMembers.remove(clientId)
+                    typingStartEventPrunerJobs.remove(clientId)
+                    emit(TypingEventType.Stopped, clientId)
+                }
+                typingStartEventPrunerJobs[clientId] = timedTypingStopEvent
+            }
+            TypingEventType.Stopped -> { // CHA-T13b4
+                val clientIdPresent = currentlyTypingMembers.remove(clientId)
+                typingStartEventPrunerJobs[clientId]?.cancel()
+                typingStartEventPrunerJobs.remove(clientId)
+                if (!clientIdPresent) { // CHA-T13b5
+                    return
+                }
             }
         }
-        logger.error("Failed to get members after $PRESENCE_GET_MAX_RETRIES retries")
+        emit(eventType, clientId)
     }
 
-    private fun emit(currentlyTyping: Set<String>) {
-        if (lastTyping == currentlyTyping) return
-        lastTyping = currentlyTyping
+    private fun emit(eventType: TypingEventType, clientId: String) {
+        val typingEventChange = DefaultTypingEventChange(eventType, clientId)
         listeners.forEach {
-            it.onEvent(DefaultTypingEvent(currentlyTyping))
+            it.onEvent(DefaultTypingEvent(get(), typingEventChange))
         }
     }
 }

--- a/chat-android/src/main/java/com/ably/chat/Typing.kt
+++ b/chat-android/src/main/java/com/ably/chat/Typing.kt
@@ -226,7 +226,7 @@ internal class DefaultTyping(
                 logger.error("unable to handle typing event; no clientId", context = mapOf("message" to msg.toString()))
                 return@PubSubMessageListener
             }
-            typingScope.launch {
+            typingScope.launch { // sequentially launches all events since limitedParallelism is set to 1
                 processReceivedTypingEvents(typingEventType, msg.clientId)
             }
         }

--- a/chat-android/src/test/java/com/ably/chat/RoomOptionTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/RoomOptionTest.kt
@@ -1,5 +1,6 @@
 package com.ably.chat
 
+import kotlin.time.Duration.Companion.milliseconds
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
@@ -17,7 +18,10 @@ class RoomOptionTest {
 
     @Test
     fun `custom typing options should be equal`() {
-        assertEquals(buildRoomOptions { typing { timeoutMs = 10 } }, buildRoomOptions { typing { timeoutMs = 10 } })
+        assertEquals(
+            buildRoomOptions { typing { heartbeatThrottle = 10.milliseconds } },
+            buildRoomOptions { typing { heartbeatThrottle = 10.milliseconds } },
+        )
     }
 
     @Test

--- a/chat-android/src/test/java/com/ably/chat/TestUtils.kt
+++ b/chat-android/src/test/java/com/ably/chat/TestUtils.kt
@@ -116,3 +116,10 @@ suspend fun <T>Any.invokePrivateSuspendMethod(methodName: String, vararg args: A
         it.invoke(this, *args, cont)
     }
 }
+
+fun <T> Any.invokePrivateMethod(methodName: String, vararg args: Any?): T {
+    val method = javaClass.declaredMethods.find { it.name == methodName }
+    method?.isAccessible = true
+    @Suppress("UNCHECKED_CAST")
+    return method?.invoke(this, *args) as T
+}

--- a/chat-android/src/test/java/com/ably/chat/TypingTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/TypingTest.kt
@@ -2,138 +2,487 @@ package com.ably.chat
 
 import app.cash.turbine.test
 import com.ably.chat.room.DEFAULT_CLIENT_ID
+import com.ably.chat.room.TypingHeartbeatStarted
+import com.ably.chat.room.TypingStartEventPrunerJobs
 import com.ably.chat.room.createMockChatApi
 import com.ably.chat.room.createMockRealtimeChannel
 import com.ably.chat.room.createMockRealtimeClient
 import com.ably.chat.room.createMockRoom
-import com.ably.pubsub.RealtimePresence
+import com.ably.chat.room.processEvent
+import com.ably.pubsub.RealtimeChannel
 import io.ably.lib.realtime.CompletionListener
+import io.ably.lib.types.Message
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.spyk
 import io.mockk.verify
-import kotlin.time.Duration.Companion.milliseconds
-import kotlinx.coroutines.CoroutineScope
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.TimeSource
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
 class TypingTest {
 
     private lateinit var room: DefaultRoom
-    private val pubSubPresence = mockk<RealtimePresence>(relaxed = true)
+    private val typingChannel: RealtimeChannel = createMockRealtimeChannel()
+    private var pubSubTypingListener: PubSubMessageListener? = null
+    private lateinit var typingLogger: Logger
 
     @Before
     fun setUp() {
         val realtimeClient = createMockRealtimeClient()
-        every { pubSubPresence.enterClient(DEFAULT_CLIENT_ID, any(), any()) } answers {
-            val completionListener = arg<CompletionListener>(2)
-            completionListener.onSuccess()
-        }
-
-        val channel = createMockRealtimeChannel()
-        every { channel.presence } returns pubSubPresence
 
         val channels = realtimeClient.channels
-        every { channels.get(any(), any()) } returns channel
+        every { channels.get(any(), any()) } returns typingChannel
+
+        every { typingChannel.subscribe(any<List<String>>(), any<PubSubMessageListener>()) } answers {
+            pubSubTypingListener = secondArg()
+            com.ably.Subscription {
+                pubSubTypingListener = null
+            }
+        }
 
         val mockChatApi = createMockChatApi(realtimeClient)
         room = spyk(createMockRoom("room1", realtimeClient = realtimeClient, chatApi = mockChatApi))
+        typingLogger = room.logger
+        every {
+            typingLogger.withContext(any<String>())
+        } returns typingLogger
 
         coEvery { room.ensureAttached(any<Logger>()) } returns Unit
     }
 
     /**
-     * @spec CHA-T4a1
+     * @spec CHA-T4, CHA-T4a
      */
     @Test
-    fun `when a typing session is started, the client is entered into presence on the typing channel`() = runTest {
+    fun `when a typing start is called, the client publishes typing start ephemeral message`() = runTest {
         val typing = DefaultTyping(room)
-        typing.start()
-        verify(exactly = 1) { pubSubPresence.enterClient("clientId", any(), any()) }
+        var publishedMessage: Message? = null
+        every {
+            typingChannel.publish(any<Message>(), any<CompletionListener>())
+        } answers {
+            publishedMessage = firstArg()
+            secondArg<CompletionListener>().onSuccess()
+        }
+        assertNull(typing.TypingHeartbeatStarted)
+        typing.keystroke()
+        assertNotNull(typing.TypingHeartbeatStarted)
+        verify(exactly = 1) { typingChannel.publish(any<Message>(), any()) }
+        assertEquals(TypingEventType.Started.eventName, publishedMessage?.name)
+        val extras = publishedMessage?.extras?.asJsonObject()
+        val ephemeral = extras?.get("ephemeral")?.asBoolean!!
+        assertTrue(ephemeral)
     }
 
     /**
-     * @spec CHA-T4a2
+     * @spec CHA-T4, CHA-T4a3, CHA-T4a4, CHA-T4c
      */
     @Test
-    fun `when timeout expires, the typing session is automatically ended by leaving presence`() = runTest {
-        val testScheduler = TestCoroutineScheduler()
-        val dispatcher = StandardTestDispatcher(testScheduler)
-        val scope = CoroutineScope(dispatcher)
-        val typing = DefaultTyping(room, dispatcher)
+    fun `Multiple calls to typing start within heartbeatThrottle, only one message is published`() = runTest {
+        val typing = DefaultTyping(room)
+        var publishedMessage: Message? = null
 
-        scope.launch {
-            typing.start()
+        every {
+            typingChannel.publish(any<Message>(), any<CompletionListener>())
+        } answers {
+            publishedMessage = firstArg()
+            secondArg<CompletionListener>().onSuccess()
         }
 
-        testScheduler.advanceTimeBy(5000.milliseconds)
-        testScheduler.runCurrent()
+        val firstKeystrokeTime = TimeSource.Monotonic.markNow()
 
-        verify(exactly = 1) { pubSubPresence.enterClient("clientId", any(), any()) }
-        verify(exactly = 1) { pubSubPresence.leaveClient("clientId", any(), any()) }
+        typing.keystroke()
+        assertNotNull(typing.TypingHeartbeatStarted)
+
+        verify(exactly = 1) { typingChannel.publish(any<Message>(), any()) }
+        assertEquals(TypingEventType.Started.eventName, publishedMessage?.name)
+
+        assertTrue(typing.TypingHeartbeatStarted!!.elapsedNow() < 10.seconds) // timer not expired
+        repeat(5) {
+            typing.keystroke() // no typing event is sent
+        }
+        verify(exactly = 1) { typingChannel.publish(any<Message>(), any()) }
+        assertEquals(TypingEventType.Started.eventName, publishedMessage?.name)
+
+        // Advance heartbeatThrottle by 10 seconds, make it expired
+        typing.TypingHeartbeatStarted = firstKeystrokeTime - 10.seconds
+        assertFalse(typing.TypingHeartbeatStarted!!.elapsedNow() < 10.seconds) // expired
+
+        // Next keystroke should publish a new typing start event
+        typing.keystroke()
+        assertNotNull(typing.TypingHeartbeatStarted) // New timer set
+
+        verify(exactly = 2) { typingChannel.publish(any<Message>(), any()) }
+        assertEquals(TypingEventType.Started.eventName, publishedMessage?.name)
+
+        assertTrue(typing.TypingHeartbeatStarted!!.elapsedNow() < 10.seconds) // timer not expired
+        repeat(5) {
+            typing.keystroke() // no typing event is sent
+        }
+
+        verify(exactly = 2) { typingChannel.publish(any<Message>(), any()) }
+        assertEquals(TypingEventType.Started.eventName, publishedMessage?.name)
     }
 
     /**
-     * @spec CHA-T4b
+     * @spec CHA-T5, CHA-T5a, CHA-T14, CHA-T5e, CHA-T5d
      */
     @Test
-    fun `if typing is already in progress, the timeout is extended to be timeoutMs from now`() = runTest {
-        val testScheduler = TestCoroutineScheduler()
-        val dispatcher = StandardTestDispatcher(testScheduler)
-        val scope = CoroutineScope(dispatcher)
-        val typing = DefaultTyping(room, dispatcher)
+    fun `If typing stop is called, the heartbeatThrottle timeout is cancelled, the client sends stop event`() = runTest {
+        val typing = spyk(DefaultTyping(room))
 
-        scope.launch {
-            typing.start()
+        var publishedMessage: Message? = null
+        every {
+            typingChannel.publish(any<Message>(), any<CompletionListener>())
+        } answers {
+            publishedMessage = firstArg()
+            secondArg<CompletionListener>().onSuccess()
         }
+        assertNull(typing.TypingHeartbeatStarted)
 
-        testScheduler.advanceTimeBy(3000.milliseconds)
-        testScheduler.runCurrent()
+        val firstKeystrokeTime = TimeSource.Monotonic.markNow()
+        typing.keystroke()
+        assertNotNull(typing.TypingHeartbeatStarted)
+        verify(exactly = 1) { typingChannel.publish(any<Message>(), any()) }
+        assertEquals(TypingEventType.Started.eventName, publishedMessage?.name)
 
-        scope.launch {
-            typing.start()
-        }
+        // CHA-T5d, CHA-T5e - Typing stop event is published, heartbeatThrottle timer is cancelled
+        typing.stop()
+        assertNull(typing.TypingHeartbeatStarted)
+        verify(exactly = 2) { typingChannel.publish(any<Message>(), any()) }
+        assertEquals(TypingEventType.Stopped.eventName, publishedMessage?.name)
+        val extras = publishedMessage?.extras?.asJsonObject()
+        val ephemeral = extras?.get("ephemeral")?.asBoolean!!
+        assertTrue(ephemeral)
 
-        testScheduler.advanceTimeBy(3000.milliseconds)
-        testScheduler.runCurrent()
+        // typing.TypingHeartbeatStarted set as active, so stop message should be published
+        typing.TypingHeartbeatStarted = firstKeystrokeTime
+        typing.stop()
+        verify(exactly = 3) { typingChannel.publish(any<Message>(), any()) }
+        assertEquals(TypingEventType.Stopped.eventName, publishedMessage?.name)
 
-        verify(exactly = 1) { pubSubPresence.enterClient("clientId", any(), any()) }
-        verify(exactly = 0) { pubSubPresence.leaveClient("clientId", any(), any()) }
+        // CHA-T5a, typing.TypingHeartbeatStarted set to expired, so no stop message should be published
+        typing.TypingHeartbeatStarted = firstKeystrokeTime - 10.seconds
+        assertFalse(typing.TypingHeartbeatStarted!!.elapsedNow() < 10.seconds) // expired
+        typing.stop()
+        verify(exactly = 3) { typingChannel.publish(any<Message>(), any()) }
+        assertEquals(TypingEventType.Stopped.eventName, publishedMessage?.name)
+
+        // CHA-T5a, typing.TypingHeartbeatStarted is null, so no stop message should be published
+        typing.TypingHeartbeatStarted = null
+        typing.stop()
+        verify(exactly = 3) { typingChannel.publish(any<Message>(), any()) }
+        assertEquals(TypingEventType.Stopped.eventName, publishedMessage?.name)
+    }
+
+    private fun receiveTypingEvent(eventName: TypingEventType, clientId: String?) {
+        val typingStartEvent = Message()
+        typingStartEvent.name = eventName.eventName
+        typingStartEvent.clientId = clientId
+        pubSubTypingListener?.onMessage(typingStartEvent)
     }
 
     /**
-     * @spec CHA-T5b
+     * Spec: CHA-T13a
      */
     @Test
-    fun `if typing is in progress, the timeout is cancelled, the client then leaves presence`() = runTest {
+    fun `on typing event received, if event is malformed, ignore the event`() = runTest {
+        val typing = spyk(DefaultTyping(room))
+
+        val typingEvents = mutableListOf<TypingEvent>()
+        typing.subscribe {
+            typingEvents.add(it)
+        }
+
+        // Receive mock typing start event with null clientId
+        receiveTypingEvent(TypingEventType.Started, null)
+
+        verify(exactly = 1) {
+            typingLogger.error("unable to handle typing event; no clientId", any(), any(), any<Map<String, String>>())
+        }
+        assertWaiter {
+            delay(500)
+            typingEvents.size == 0
+        }
+        assertTrue(typing.get().isEmpty())
+
+        // Receive mock typing stop event with empty clientId
+        receiveTypingEvent(TypingEventType.Stopped, "")
+
+        verify(exactly = 2) {
+            typingLogger.error("unable to handle typing event; no clientId", any(), any(), any<Map<String, String>>())
+        }
+        assertWaiter {
+            delay(500)
+            typingEvents.size == 0
+        }
+        assertTrue(typing.get().isEmpty())
+
+        // Receive mock typing event with valid clientId
+        receiveTypingEvent(TypingEventType.Started, DEFAULT_CLIENT_ID)
+        assertWaiter { typingEvents.size == 1 }
+        assertEquals(1, typing.get().size)
+
+        receiveTypingEvent(TypingEventType.Stopped, DEFAULT_CLIENT_ID)
+        assertWaiter { typingEvents.size == 2 }
+        assertEquals(0, typing.get().size)
+
+        // No error detected
+        verify(exactly = 2) {
+            typingLogger.error("unable to handle typing event; no clientId", any(), any(), any<Map<String, String>>())
+        }
+    }
+
+    /**
+     * Spec: CHA-T13b1, CHA-T13b2
+     */
+    @Test
+    fun `Each start typing event should reset the inactivity timeout and set new one`() = runTest {
+        val typing = DefaultTyping(room)
+
+        val typingEvents = mutableListOf<TypingEvent>()
+        typing.subscribe {
+            typingEvents.add(it)
+        }
+        // Initially no timer exists
+        val activityTimer1 = typing.TypingStartEventPrunerJobs[DEFAULT_CLIENT_ID]
+        assertNull(activityTimer1)
+
+        // Receive mock typing start event
+        receiveTypingEvent(TypingEventType.Started, DEFAULT_CLIENT_ID)
+        assertWaiter { typingEvents.size == 1 }
+        // New inactivity timer started
+        val activityTimer2 = typing.TypingStartEventPrunerJobs[DEFAULT_CLIENT_ID]
+        assertNotNull(activityTimer2)
+
+        // Receive new mock typing start event
+        receiveTypingEvent(TypingEventType.Started, DEFAULT_CLIENT_ID)
+        assertWaiter { typingEvents.size == 2 }
+        // Old timer is cancelled and new inactivity timer started
+        assertTrue(activityTimer2!!.isCancelled)
+        val activityTimer3 = typing.TypingStartEventPrunerJobs[DEFAULT_CLIENT_ID]
+        assertNotNull(activityTimer3)
+
+        // Receive one more typing start event
+        receiveTypingEvent(TypingEventType.Started, DEFAULT_CLIENT_ID)
+        assertWaiter { typingEvents.size == 3 }
+        // Old timer is cancelled and new inactivity timer started
+        assertTrue(activityTimer3!!.isCancelled)
+        val activityTimer4 = typing.TypingStartEventPrunerJobs[DEFAULT_CLIENT_ID]
+        assertNotNull(activityTimer4)
+    }
+
+    /**
+     * @spec CHA-T13b3
+     */
+    @Test
+    fun `On typingStart event received, heartbeatThrottle timeout is set, emits self stop event if no more event received`() = runTest {
         val testScheduler = TestCoroutineScheduler()
         val dispatcher = StandardTestDispatcher(testScheduler)
-        val scope = CoroutineScope(dispatcher)
         val typing = DefaultTyping(room, dispatcher)
 
-        scope.launch {
-            typing.start()
+        val typingEvents = mutableListOf<TypingEvent>()
+        typing.subscribe {
+            typingEvents.add(it)
         }
+        // Receive mock typing start event
+        typing.processEvent(TypingEventType.Started, DEFAULT_CLIENT_ID)
 
-        testScheduler.advanceTimeBy(1000.milliseconds)
+        assertEquals(1, typingEvents.size)
+        assertEquals(setOf(DEFAULT_CLIENT_ID), typingEvents[0].currentlyTyping)
+        assertEquals(TypingEventType.Started, typingEvents[0].change.type)
+        assertEquals(DEFAULT_CLIENT_ID, typingEvents[0].change.clientId)
+
+        assertEquals(setOf(DEFAULT_CLIENT_ID), typing.get()) // clientId added to internal set
+        assertNotNull(typing.TypingStartEventPrunerJobs[DEFAULT_CLIENT_ID]) // self stop timer started
+
+        testScheduler.advanceTimeBy(9.seconds)
+        testScheduler.runCurrent()
+        assertEquals(1, typingEvents.size)
+
+        // Emits stop event after 12 seconds, heartbeatThrottle (10 sec) + timeoutMs (2 sec) = 12 seconds
+        // Previous 9 seconds + current 3 seconds = 12 seconds
+        testScheduler.advanceTimeBy(3.seconds)
         testScheduler.runCurrent()
 
-        verify(exactly = 1) { pubSubPresence.enterClient("clientId", any(), any()) }
+        assertEquals(2, typingEvents.size)
+        assertEquals(emptySet<String>(), typingEvents[1].currentlyTyping)
+        assertEquals(TypingEventType.Stopped, typingEvents[1].change.type)
+        assertEquals(DEFAULT_CLIENT_ID, typingEvents[1].change.clientId)
 
-        scope.launch {
-            typing.stop()
+        assertTrue(typing.TypingStartEventPrunerJobs.isEmpty())
+        assertTrue(typing.get().isEmpty())
+    }
+
+    /**
+     * Spec: CHA-T13b4
+     */
+    @Test
+    fun `Each stop typing event should remove inactivity timeout and emit stop event`() = runTest {
+        val typing = DefaultTyping(room)
+
+        val typingEvents = mutableListOf<TypingEvent>()
+        typing.subscribe {
+            typingEvents.add(it)
+        }
+        // Receive mock typing start event
+        receiveTypingEvent(TypingEventType.Started, DEFAULT_CLIENT_ID)
+
+        assertWaiter { typingEvents.size == 1 }
+        assertEquals(setOf(DEFAULT_CLIENT_ID), typingEvents[0].currentlyTyping)
+        assertEquals(TypingEventType.Started, typingEvents[0].change.type)
+        assertEquals(DEFAULT_CLIENT_ID, typingEvents[0].change.clientId)
+
+        assertEquals(setOf(DEFAULT_CLIENT_ID), typing.get())
+        assertNotNull(typing.TypingStartEventPrunerJobs[DEFAULT_CLIENT_ID])
+
+        val activityTimer1 = typing.TypingStartEventPrunerJobs[DEFAULT_CLIENT_ID]
+        assertNotNull(activityTimer1)
+        assertTrue(activityTimer1!!.isActive)
+
+        // Receive mock typing stop event
+        receiveTypingEvent(TypingEventType.Stopped, DEFAULT_CLIENT_ID)
+
+        assertWaiter { typingEvents.size == 2 }
+        assertTrue(activityTimer1.isCancelled)
+        assertEquals(emptySet<String>(), typingEvents[1].currentlyTyping)
+        assertEquals(TypingEventType.Stopped, typingEvents[1].change.type)
+        assertEquals(DEFAULT_CLIENT_ID, typingEvents[1].change.clientId)
+
+        assertTrue(typing.TypingStartEventPrunerJobs.isEmpty())
+        assertTrue(typing.get().isEmpty())
+
+        // If stop event is received again, nothing is emitted
+        receiveTypingEvent(TypingEventType.Stopped, DEFAULT_CLIENT_ID)
+        assertWaiter {
+            delay(500)
+            typingEvents.size == 2
+        }
+        assertTrue(typing.TypingStartEventPrunerJobs.isEmpty())
+        assertTrue(typing.get().isEmpty())
+    }
+
+    /**
+     * @spec CHA-T13b5
+     */
+    @Test
+    fun `On typingStop event is received for client not present in typing set, then event is not emitted`() = runTest {
+        val typing = DefaultTyping(room)
+
+        val typingEvents = mutableListOf<TypingEvent>()
+        typing.subscribe {
+            typingEvents.add(it)
+        }
+        // Receive mock typing start event
+        receiveTypingEvent(TypingEventType.Started, DEFAULT_CLIENT_ID)
+
+        assertWaiter { typingEvents.size == 1 }
+        assertEquals(setOf(DEFAULT_CLIENT_ID), typingEvents[0].currentlyTyping)
+        assertEquals(TypingEventType.Started, typingEvents[0].change.type)
+        assertEquals(DEFAULT_CLIENT_ID, typingEvents[0].change.clientId)
+
+        assertEquals(setOf(DEFAULT_CLIENT_ID), typing.get())
+        assertNotNull(typing.TypingStartEventPrunerJobs[DEFAULT_CLIENT_ID])
+
+        receiveTypingEvent(TypingEventType.Stopped, "missing-client-Id")
+
+        assertWaiter {
+            delay(500)
+            typingEvents.size == 1
         }
 
-        testScheduler.advanceTimeBy(5000.milliseconds)
-        testScheduler.runCurrent()
+        assertNotNull(typing.TypingStartEventPrunerJobs[DEFAULT_CLIENT_ID])
+        assertEquals(setOf(DEFAULT_CLIENT_ID), typing.get())
+    }
 
-        verify(exactly = 1) { pubSubPresence.leaveClient("clientId", any(), any()) }
+    /**
+     * @spec CHA-TM14, CHA-TM14a, CHA-TM14b
+     */
+    @Test
+    fun `multiple calls to keystroke and stop should be idempotent and only latest one should be performed`() = runTest {
+        val typing = spyk(DefaultTyping(room), recordPrivateCalls = true)
+        val recordedEvents = mutableListOf<TypingEventType>()
+        coEvery { typing["sendTyping"](any<TypingEventType>()) } coAnswers {
+            delay(500)
+            val event = firstArg<TypingEventType>()
+            recordedEvents.add(event)
+        }
+        suspend fun concurrentlyPerform(blocks: List<suspend () -> Unit>) {
+            withContext(Dispatchers.IO) {
+                blocks.forEach { block ->
+                    launch { block() }
+                    // we expect delay of at least 1ms between keystrokes and stop, without it, sequential locking doesn't work
+                    delay(1)
+                }
+            }
+        }
+
+        // First case
+        concurrentlyPerform(
+            listOf(
+                { typing.keystroke() },
+                { typing.stop() },
+                { typing.keystroke() },
+                { typing.stop() },
+                { typing.keystroke() },
+                { typing.stop() },
+                { typing.keystroke() },
+                { typing.stop() },
+            ),
+        )
+        assertEquals(listOf(TypingEventType.Started, TypingEventType.Stopped), recordedEvents)
+
+        // Clear states
+        typing.stop() // Set typing as off
+        recordedEvents.clear()
+
+        // Second case
+        concurrentlyPerform(
+            listOf(
+                { typing.keystroke() },
+                { typing.keystroke() },
+                { typing.stop() },
+                { typing.keystroke() },
+                { typing.keystroke() },
+                { typing.stop() },
+                { typing.keystroke() },
+            ),
+        )
+        assertEquals(listOf(TypingEventType.Started), recordedEvents)
+
+        // Clear states
+        typing.stop() // Set typing as off
+        recordedEvents.clear()
+
+        // Third case
+        recordedEvents.clear()
+        concurrentlyPerform(
+            listOf(
+                { typing.stop() }, // This will be ignored
+                { typing.stop() }, // This will be ignored
+                { typing.keystroke() },
+                { typing.keystroke() },
+                { typing.stop() },
+                { typing.keystroke() },
+                { typing.keystroke() },
+                { typing.stop() },
+            ),
+        )
+        assertEquals(listOf(TypingEventType.Started, TypingEventType.Stopped), recordedEvents)
     }
 
     @Test

--- a/chat-android/src/test/java/com/ably/chat/integration/TypingIntegrationTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/integration/TypingIntegrationTest.kt
@@ -1,9 +1,12 @@
 package com.ably.chat.integration
 
 import com.ably.chat.TypingEvent
+import com.ably.chat.TypingEventType
+import com.ably.chat.assertWaiter
 import com.ably.chat.buildRoomOptions
 import com.ably.chat.typing
 import java.util.UUID
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -12,25 +15,112 @@ import org.junit.Test
 
 class TypingIntegrationTest {
 
+    /**
+     * @spec CHA-T4, CHA-T9
+     */
     @Test
-    fun `should return typing indication for client`() = runTest {
+    fun `should return typing start indication for client`() = runTest {
         val chatClient1 = sandbox.createSandboxChatClient("client1")
         val chatClient2 = sandbox.createSandboxChatClient("client2")
         val roomId = UUID.randomUUID().toString()
-        val roomOptions = buildRoomOptions { typing { timeoutMs = 10_000 } }
+        val roomOptions = buildRoomOptions { typing { heartbeatThrottle = 10.seconds } }
         val chatClient1Room = chatClient1.rooms.get(roomId, roomOptions)
         chatClient1Room.attach()
         val chatClient2Room = chatClient2.rooms.get(roomId, roomOptions)
         chatClient2Room.attach()
 
-        val deferredValue = CompletableDeferred<TypingEvent>()
+        assertEquals(emptySet<String>(), chatClient1Room.typing.get())
+        assertEquals(emptySet<String>(), chatClient2Room.typing.get())
+
+        val startTypingEventDeferred = CompletableDeferred<TypingEvent>()
         chatClient2Room.typing.subscribe {
-            deferredValue.complete(it)
+            startTypingEventDeferred.complete(it)
         }
-        chatClient1Room.typing.start()
-        val typingEvent = deferredValue.await()
-        assertEquals(setOf("client1"), typingEvent.currentlyTyping)
+        chatClient1Room.typing.keystroke()
+        val startTypingEvent = startTypingEventDeferred.await()
+
+        assertEquals(setOf("client1"), startTypingEvent.currentlyTyping)
+        assertEquals("client1", startTypingEvent.change.clientId)
+        assertEquals(TypingEventType.Started, startTypingEvent.change.type)
+
+        assertEquals(setOf("client1"), chatClient1Room.typing.get())
         assertEquals(setOf("client1"), chatClient2Room.typing.get())
+    }
+
+    /**
+     * @spec CHA-T5, CHA-T9
+     */
+    @Test
+    fun `should return typing stop indication for clients`() = runTest {
+        // Set up 3 chat Clients
+        val chatClient1 = sandbox.createSandboxChatClient("client1")
+        val chatClient2 = sandbox.createSandboxChatClient("client2")
+        val chatClient3 = sandbox.createSandboxChatClient("client3")
+        val roomId = UUID.randomUUID().toString()
+        val roomOptions = buildRoomOptions { typing { heartbeatThrottle = 10.seconds } }
+        val chatClient1Room = chatClient1.rooms.get(roomId, roomOptions)
+        chatClient1Room.attach()
+        val chatClient2Room = chatClient2.rooms.get(roomId, roomOptions)
+        chatClient2Room.attach()
+        val chatClient3Room = chatClient3.rooms.get(roomId, roomOptions)
+        chatClient3Room.attach()
+
+        // Client 1, Client 2 starts typing
+        val startTypingEvents = mutableListOf<TypingEvent>()
+        chatClient2Room.typing.subscribe {
+            startTypingEvents.add(it)
+        }
+        chatClient1Room.typing.keystroke()
+        chatClient2Room.typing.keystroke()
+
+        // Two start typing events received
+        assertWaiter { startTypingEvents.size == 2 }
+
+        val startTypingEvent1 = startTypingEvents[0]
+        assertEquals(setOf("client1"), startTypingEvent1.currentlyTyping)
+        assertEquals("client1", startTypingEvent1.change.clientId)
+        assertEquals(TypingEventType.Started, startTypingEvent1.change.type)
+
+        val startTypingEvent2 = startTypingEvents[1]
+        assertEquals(setOf("client1", "client2"), startTypingEvent2.currentlyTyping)
+        assertEquals("client2", startTypingEvent2.change.clientId)
+        assertEquals(TypingEventType.Started, startTypingEvent2.change.type)
+
+        assertWaiter { chatClient1Room.typing.get() == setOf("client1", "client2") }
+        assertWaiter { chatClient2Room.typing.get() == setOf("client1", "client2") }
+        assertWaiter { chatClient3Room.typing.get() == setOf("client1", "client2") }
+
+        // Client 1 stops typing
+        val stopTypingEventDeferred1 = CompletableDeferred<TypingEvent>()
+        chatClient2Room.typing.subscribe {
+            stopTypingEventDeferred1.complete(it)
+        }
+        chatClient1Room.typing.stop()
+
+        val stopTypingEvent1 = stopTypingEventDeferred1.await()
+        assertEquals(setOf("client2"), stopTypingEvent1.currentlyTyping)
+        assertEquals("client1", stopTypingEvent1.change.clientId)
+        assertEquals(TypingEventType.Stopped, stopTypingEvent1.change.type)
+
+        assertWaiter { chatClient1Room.typing.get() == setOf("client2") }
+        assertWaiter { chatClient2Room.typing.get() == setOf("client2") }
+        assertWaiter { chatClient3Room.typing.get() == setOf("client2") }
+
+        // Client 2 stops typing
+        val stopTypingEventDeferred2 = CompletableDeferred<TypingEvent>()
+        chatClient2Room.typing.subscribe {
+            stopTypingEventDeferred2.complete(it)
+        }
+        chatClient2Room.typing.stop()
+
+        val stopTypingEvent2 = stopTypingEventDeferred2.await()
+        assertEquals(emptySet<String>(), stopTypingEvent2.currentlyTyping)
+        assertEquals("client2", stopTypingEvent2.change.clientId)
+        assertEquals(TypingEventType.Stopped, stopTypingEvent2.change.type)
+
+        assertWaiter { chatClient1Room.typing.get().isEmpty() }
+        assertWaiter { chatClient2Room.typing.get().isEmpty() }
+        assertWaiter { chatClient3Room.typing.get().isEmpty() }
     }
 
     companion object {

--- a/chat-android/src/test/java/com/ably/chat/room/RoomGetTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/room/RoomGetTest.kt
@@ -17,6 +17,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.spyk
 import io.mockk.verify
+import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.Channel
@@ -91,7 +92,7 @@ class RoomGetTest {
         Assert.assertEquals(room3, room4)
 
         val room5 = rooms.get("7890") {
-            typing { timeoutMs = 1500 }
+            typing { heartbeatThrottle = 1500.milliseconds }
             presence {
                 enter = true
                 subscribe = false
@@ -102,7 +103,7 @@ class RoomGetTest {
         Assert.assertEquals(room5, rooms.RoomIdToRoom["7890"])
 
         val room6 = rooms.get("7890") {
-            typing { timeoutMs = 1500 }
+            typing { heartbeatThrottle = 1500.milliseconds }
             presence {
                 enter = true
                 subscribe = false

--- a/example/src/main/java/com/ably/chat/example/MainActivity.kt
+++ b/example/src/main/java/com/ably/chat/example/MainActivity.kt
@@ -219,11 +219,14 @@ fun Chat(room: Room, modifier: Modifier = Modifier) {
             onMessageChange = {
                 messageText = it
                 coroutineScope.launch {
-                    room.typing.start()
+                    room.typing.keystroke()
                 }
             },
             onSendClick = {
                 sending = true
+                coroutineScope.launch {
+                    room.typing.stop()
+                }
                 when {
                     updating -> handleEdit()
                     else -> handleSend()

--- a/example/src/main/java/com/ably/chat/example/MainActivity.kt
+++ b/example/src/main/java/com/ably/chat/example/MainActivity.kt
@@ -218,8 +218,14 @@ fun Chat(room: Room, modifier: Modifier = Modifier) {
             messageInput = messageText,
             onMessageChange = {
                 messageText = it
-                coroutineScope.launch {
-                    room.typing.keystroke()
+                if (messageText.text.isEmpty()) {
+                    coroutineScope.launch {
+                        room.typing.stop()
+                    }
+                } else {
+                    coroutineScope.launch {
+                        room.typing.keystroke()
+                    }
                 }
             },
             onSendClick = {


### PR DESCRIPTION
Fixed https://github.com/ably/ably-chat-kotlin/issues/118

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The chat now clearly distinguishes when a user begins typing versus when they stop, ensuring more accurate real-time typing indicators.
  - The input experience has been refined so that the typing indicator promptly clears once a message is sent.

- **Refactor**
  - Enhanced the handling of typing events using a throttling mechanism, reducing rapid-fire notifications and providing a smoother chat experience.
  - Improved the structure of typing event handling for better clarity and control over typing state.
  - Introduced a more structured approach to typing event emissions, enhancing type safety and clarity.

- **Bug Fixes**
  - Resolved issues with typing event notifications to ensure correct processing and management of typing states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->