### PR TITLE
readme: remove feature callout

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,20 +19,6 @@ Get started using the [📚 documentation](https://ably.com/docs/products/chat).
 
 This SDK works on Android 7.0+ (API level 24+) and Java 8+.
 
-## Supported chat features
-
-This project is under development so we will be incrementally adding new features. At this stage, you'll find APIs for the following chat
-features:
-
-- Chat rooms for 1:1, 1:many, many:1 and many:many participation.
-- Sending and receiving chat messages.
-- Online status aka presence of chat participants.
-- Chat room occupancy, i.e total number of connections and presence members.
-- Typing indicators
-- Room-level reactions (ephemeral at this stage)
-
-If there are other features you'd like us to prioritize, please [let us know](https://forms.gle/mBw9M53NYuCBLFpMA).
-
 ## Usage
 
 You will need the following prerequisites:


### PR DESCRIPTION
We have the feature callouts in 3x SDK readmes, which require updating on each release.

Instead we're going to remove them and use the docs page as the source-of-truth for features.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Removed the "Supported chat features" section from the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->