### PR TITLE
[ECO-5392] fix: race condition in getting status

### DIFF
--- a/chat-android/src/main/java/com/ably/chat/AtomicCoroutineScope.kt
+++ b/chat-android/src/main/java/com/ably/chat/AtomicCoroutineScope.kt
@@ -15,7 +15,7 @@ import kotlinx.coroutines.launch
  * Accepts scope as a constructor parameter to run operations under the given scope.
  * See [Kotlin Dispatchers](https://kt.academy/article/cc-dispatchers) for more information.
  */
-internal class AtomicCoroutineScope(private val scope: CoroutineScope = CoroutineScope(Dispatchers.Default)) {
+internal class AtomicCoroutineScope(private val scope: CoroutineScope = CoroutineScope(Dispatchers.Main)) {
 
     private val sequentialScope: CoroutineScope = CoroutineScope(Dispatchers.Default.limitedParallelism(1))
 

--- a/chat-android/src/main/java/com/ably/chat/Connection.kt
+++ b/chat-android/src/main/java/com/ably/chat/Connection.kt
@@ -130,7 +130,7 @@ public fun Connection.statusAsFlow(): Flow<ConnectionStatusChange> = transformCa
 internal class DefaultConnection(
     pubSubConnection: PubSubConnection,
     private val logger: Logger,
-    dispatcher: CoroutineDispatcher = Dispatchers.Default,
+    dispatcher: CoroutineDispatcher = Dispatchers.Main,
 ) : Connection {
 
     private val connectionScope = CoroutineScope(dispatcher.limitedParallelism(1) + SupervisorJob())

--- a/chat-extensions-compose/src/main/kotlin/com/ably/chat/extensions/compose/Connection.kt
+++ b/chat-extensions-compose/src/main/kotlin/com/ably/chat/extensions/compose/Connection.kt
@@ -20,6 +20,7 @@ public fun Connection.collectAsStatus(): ConnectionStatus {
     var status by remember(this) { mutableStateOf(status) }
 
     LaunchedEffect(this) {
+        status = this@collectAsStatus.status
         statusAsFlow().collect { status = it.current }
     }
 

--- a/chat-extensions-compose/src/main/kotlin/com/ably/chat/extensions/compose/Room.kt
+++ b/chat-extensions-compose/src/main/kotlin/com/ably/chat/extensions/compose/Room.kt
@@ -20,6 +20,7 @@ public fun Room.collectAsStatus(): RoomStatus {
     var status by remember(this) { mutableStateOf(status) }
 
     LaunchedEffect(this) {
+        status = this@collectAsStatus.status
         statusAsFlow().collect { status = it.current }
     }
 


### PR DESCRIPTION
Fixes https://github.com/ably/ably-chat-kotlin/issues/137

Added an assignment for `status` in `LaunchedEffect` to ensure the initial state is correctly set before collecting updates. Updated coroutine dispatchers from Dispatchers.Default to Dispatchers.Main in status collecting classes to ensure consistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated default coroutine dispatcher from background to main thread in key components, ensuring operations now run on the main thread by default.
	- Improved state synchronization in connection and room status handling, providing more immediate and accurate status updates in the user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->