### PR TITLE
[ECO-5065] feat: add message reactions feature to chat API

### DIFF
--- a/chat-android/src/main/java/com/ably/chat/EventTypes.kt
+++ b/chat-android/src/main/java/com/ably/chat/EventTypes.kt
@@ -35,9 +35,6 @@ internal val messageActionNameToAction = mapOf(
     /** Action applied to a deleted message. */
     "message.delete" to MessageAction.MESSAGE_DELETE,
 
-    /** Action applied to a meta occupancy message. */
-    "meta.occupancy" to MessageAction.META_OCCUPANCY,
-
     /** Action applied to a message summary. */
     "message.summary" to MessageAction.MESSAGE_SUMMARY,
 )

--- a/chat-android/src/main/java/com/ably/chat/Message.kt
+++ b/chat-android/src/main/java/com/ably/chat/Message.kt
@@ -3,6 +3,9 @@ package com.ably.chat
 import com.google.gson.JsonObject
 import io.ably.lib.types.Message.Operation
 import io.ably.lib.types.MessageAction
+import io.ably.lib.types.Summary
+import io.ably.lib.types.SummaryClientIdCounts
+import io.ably.lib.types.SummaryClientIdList
 
 /**
  * [Headers type for chat messages.
@@ -91,10 +94,35 @@ public interface Message {
     public val timestamp: Long
 
     /**
+     * The reactions summary for this message.
+     */
+    public val reactions: MessageReactions
+
+    /**
      * The details of the operation that modified the message. This is only set for update and delete actions. It contains
      * information about the operation: the clientId of the user who performed the operation, a description, and metadata.
      */
     public val operation: Operation?
+}
+
+/**
+ * Represents a summary of all reactions on a message.
+ */
+public interface MessageReactions {
+    /**
+     * Map of reaction to the summary (total and clients) for reactions of type [MessageReactionType.Unique].
+     */
+    public val unique: Map<String, SummaryClientIdList>
+
+    /**
+     * Map of reaction to the summary (total and clients) for reactions of type [MessageReactionType.Distinct].
+     */
+    public val distinct: Map<String, SummaryClientIdList>
+
+    /**
+     * Map of reaction to the summary (total and clients) for reactions of type [MessageReactionType.Multiple].
+     */
+    public val multiple: Map<String, SummaryClientIdCounts>
 }
 
 public fun Message.copy(
@@ -108,6 +136,43 @@ public fun Message.copy(
         metadata = metadata,
     ) ?: throw clientError("Message interface is not suitable for inheritance")
 
+public fun Message.with(
+    event: MessageEvent,
+): Message {
+    checkMessageSerial(event.message.serial)
+
+    if (event.type == MessageEventType.Created) {
+        throw clientError("MessageEvent.message.action must be MESSAGE_UPDATE or MESSAGE_DELETE")
+    }
+
+    if (event.message.version <= this.version) return this
+
+    return (event.message as? DefaultMessage)?.copy(
+        reactions = reactions,
+    ) ?: throw clientError("Message interface is not suitable for inheritance")
+}
+
+public fun Message.with(
+    event: MessageReactionSummaryEvent,
+): Message {
+    checkMessageSerial(event.summary.messageSerial)
+
+    return (this as? DefaultMessage)?.copy(
+        reactions = DefaultMessageReactions(
+            unique = event.summary.unique,
+            distinct = event.summary.distinct,
+            multiple = event.summary.multiple,
+        ),
+    ) ?: throw clientError("Message interface is not suitable for inheritance")
+}
+
+private fun Message.checkMessageSerial(serial: String) {
+    // message event (update or delete)
+    if (serial != this.serial) {
+        throw clientError("cannot apply event for a different message")
+    }
+}
+
 internal data class DefaultMessage(
     override val serial: String,
     override val clientId: String,
@@ -119,8 +184,15 @@ internal data class DefaultMessage(
     override val action: MessageAction,
     override val version: String,
     override val timestamp: Long,
+    override val reactions: MessageReactions = DefaultMessageReactions(),
     override val operation: Operation? = null,
 ) : Message
+
+internal data class DefaultMessageReactions(
+    override val unique: Map<String, SummaryClientIdList> = mapOf(),
+    override val distinct: Map<String, SummaryClientIdList> = mapOf(),
+    override val multiple: Map<String, SummaryClientIdCounts> = mapOf(),
+) : MessageReactions
 
 internal fun buildMessageOperation(jsonObject: JsonObject?): Operation? {
     if (jsonObject == null) {
@@ -151,6 +223,20 @@ internal fun buildMessageOperation(clientId: String, description: String?, metad
     return operation
 }
 
+internal fun buildMessageReactions(jsonObject: JsonObject?): MessageReactions {
+    if (jsonObject == null) return DefaultMessageReactions()
+
+    val uniqueJson = jsonObject.getAsJsonObject(MessageReactionsProperty.Unique)
+    val distinctJson = jsonObject.getAsJsonObject(MessageReactionsProperty.Distinct)
+    val multipleJson = jsonObject.getAsJsonObject(MessageReactionsProperty.Multiple)
+
+    return DefaultMessageReactions(
+        unique = uniqueJson?.let { Summary.asSummaryUniqueV1(it) } ?: mapOf(),
+        distinct = distinctJson?.let { Summary.asSummaryDistinctV1(it) } ?: mapOf(),
+        multiple = multipleJson?.let { Summary.asSummaryMultipleV1(it) } ?: mapOf(),
+    )
+}
+
 /**
  * MessageProperty object representing the properties of a message.
  */
@@ -165,6 +251,7 @@ internal object MessageProperty {
     const val Action = "action"
     const val Version = "version"
     const val Timestamp = "timestamp"
+    const val Reactions = "reactions"
     const val Operation = "operation"
 }
 
@@ -175,4 +262,13 @@ internal object MessageOperationProperty {
     const val ClientId = "clientId"
     const val Description = "description"
     const val Metadata = "metadata"
+}
+
+/**
+ * MessageOperationProperty object representing the properties of a message operation.
+ */
+internal object MessageReactionsProperty {
+    const val Unique = "unique"
+    const val Distinct = "distinct"
+    const val Multiple = "multiple"
 }

--- a/chat-android/src/main/java/com/ably/chat/Message.kt
+++ b/chat-android/src/main/java/com/ably/chat/Message.kt
@@ -141,7 +141,7 @@ public fun Message.with(
 ): Message {
     checkMessageSerial(event.message.serial)
 
-    if (event.type == MessageEventType.Created) {
+    if (event.type == MessageEventType.Created) { // CHA-M11a
         throw clientError("MessageEvent.message.action must be MESSAGE_UPDATE or MESSAGE_DELETE")
     }
 

--- a/chat-android/src/main/java/com/ably/chat/MessagesReactions.kt
+++ b/chat-android/src/main/java/com/ably/chat/MessagesReactions.kt
@@ -1,0 +1,515 @@
+package com.ably.chat
+
+import com.google.gson.JsonObject
+import io.ably.lib.realtime.Channel
+import io.ably.lib.realtime.RealtimeAnnotations
+import io.ably.lib.types.Annotation
+import io.ably.lib.types.AnnotationAction
+import io.ably.lib.types.MessageAction
+import io.ably.lib.types.Summary
+import io.ably.lib.types.SummaryClientIdCounts
+import io.ably.lib.types.SummaryClientIdList
+import java.util.concurrent.CopyOnWriteArrayList
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.channels.Channel.Factory.UNLIMITED
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.launch
+
+/**
+ * Add, delete, and subscribe to message reactions.
+ */
+public interface MessagesReactions {
+    /**
+     * Sends a reaction to a specific message.
+     *
+     * @param messageSerial The unique serial identifier of the message to which the reaction should be added.
+     * @param name The name of the reaction, such as an emoji or predefined reaction identifier.
+     * @param type The type of the reaction behavior, represented by [MessageReactionType]. If not specified,
+     * the default type configured in the room's [MessageOptions.defaultMessageReactionType] will be used.
+     * @param count The number of reactions to apply. Defaults to 1.
+     */
+    public suspend fun send(messageSerial: String, name: String, type: MessageReactionType? = null, count: Int = 1)
+
+    /**
+     * Delete a message reaction
+     * @param messageSerial The message serial to remove the reaction from
+     * @param name The reaction name to delete; ie. the emoji. Required for all reaction types
+     * except [MessageReactionType.Unique].
+     * @param type The type of reaction, must be one of [MessageReactionType].
+     * If not set, the default type will be used which is configured in the
+     * [MessageOptions.defaultMessageReactionType] of the room.
+     */
+    public suspend fun delete(messageSerial: String, name: String? = null, type: MessageReactionType? = null)
+
+    /**
+     * Subscribe to message reaction summaries. Use this to keep message reaction
+     * counts up to date efficiently in the UI.
+     * @param listener The listener to call when a message reaction summary is received
+     * @return A subscription object that should be used to unsubscribe
+     */
+    public fun subscribe(listener: Listener): Subscription
+
+    /**
+     * Subscribe to individual reaction events.
+     * If you only need to keep track of reaction counts and clients, use
+     * subscribe() instead.
+     * @param listener The listener to call when a message reaction event is received
+     * @return A subscription object that should be used to unsubscribe
+     */
+    public fun subscribeRaw(listener: MessageRawReactionListener): Subscription
+
+    /**
+     * An interface for listening to new messaging reaction event
+     */
+    public fun interface Listener {
+        /**
+         * A function that can be called when the new messaging event happens.
+         * @param event The event that happened.
+         */
+        public fun onReactionSummary(event: MessageReactionSummaryEvent)
+    }
+
+    /**
+     * An interface for listening to new messaging reaction event
+     */
+    public fun interface MessageRawReactionListener {
+        /**
+         * A function that can be called when the new messaging event happens.
+         * @param event The event that happened.
+         */
+        public fun onRawReaction(event: MessageReactionRawEvent)
+    }
+}
+
+public enum class MessageReactionEventType(public val eventName: String) {
+    /**
+     * A reaction was added to a message.
+     */
+    Create("reaction.create"),
+
+    /**
+     * A reaction was removed from a message.
+     */
+    Delete("reaction.delete"),
+}
+
+public enum class MessageReactionSummaryEventType(public val eventName: String) {
+    /**
+     * A reactions summary was updated for a message.
+     */
+    Summary("reaction.summary"),
+}
+
+/**
+ * (CHA-MR2) Represents the type of reactions that can be applied to a message. Each reaction type defines
+ * unique rules for how reactions from clients are handled and counted towards the reaction summary.
+ */
+public enum class MessageReactionType(public val type: String) {
+    /**
+     * (CHA-MR2a) Allows for at most one reaction per client per message. If a client reacts
+     * to a message a second time, only the second reaction is counted in the
+     * summary.
+     *
+     * This is similar to reactions on iMessage, Facebook Messenger, or WhatsApp.
+     */
+    Unique("reaction:unique.v1"),
+
+    /**
+     * (CHA-MR2b) Allows for at most one reaction of each type per client per message. It is
+     * possible for a client to add multiple reactions to the same message as
+     * long as they are different (eg different emojis). Duplicates are not
+     * counted in the summary.
+     *
+     * This is similar to reactions on Slack.
+     */
+    Distinct("reaction:distinct.v1"),
+
+    /**
+     * (CHA-MR2c) Allows any number of reactions, including repeats, and they are counted in
+     * the summary. The reaction payload also includes a count of how many times
+     * each reaction should be counted (defaults to 1 if not set).
+     *
+     * This is similar to the clap feature on Medium or how room reactions work.
+     */
+    Multiple("reaction:multiple.v1"),
+    ;
+
+    internal companion object {
+        fun tryFind(type: String) = MessageReactionType.entries.firstOrNull { it.type == type }
+    }
+}
+
+public interface MessageReactionRawEvent {
+    /**
+     * Whether reaction was added or removed
+     */
+    public val type: MessageReactionEventType
+
+    /**
+     * The timestamp of this event
+     */
+    public val timestamp: Long
+
+    /**
+     * The message reaction that was received.
+     */
+    public val reaction: MessageReaction
+}
+
+/**
+ * The message reaction that was received.
+ */
+public interface MessageReaction {
+    /**
+     * Serial of the message this reaction is for
+     */
+    public val messageSerial: String
+
+    /**
+     * Type of reaction
+     */
+    public val type: MessageReactionType
+
+    /**
+     * The reaction name (typically an emoji)
+     */
+    public val name: String
+
+    /**
+     * Count of the reaction (only for type Multiple, if set)
+     */
+    public val count: Int?
+
+    /**
+     * The client ID of the user who added/removed the reaction
+     */
+    public val clientId: String
+}
+
+/**
+ * Event interface representing a summary of message reactions.
+ * This event aggregates different types of reactions (single, distinct, counter) for a specific message.
+ */
+public interface MessageReactionSummaryEvent {
+    /** The type of the event */
+    public val type: MessageReactionSummaryEventType
+
+    /** The message reactions summary. */
+    public val summary: MessageReactionsSummary
+}
+
+/**
+ * Represents a summary of reactions associated with a particular message.
+ *
+ * This interface provides detailed information about the different types of reactions
+ * applied to a message, categorized into unique, distinct, and multiple types.
+ */
+public interface MessageReactionsSummary {
+    /** Reference to the original message's serial number */
+    public val messageSerial: String
+
+    /** Map of unique-type reactions summaries */
+    public val unique: Map<String, SummaryClientIdList>
+
+    /** Map of distinct-type reactions summaries */
+    public val distinct: Map<String, SummaryClientIdList>
+
+    /** Map of multiple-type reactions summaries */
+    public val multiple: Map<String, SummaryClientIdCounts>
+}
+
+/**
+ * @see [MessagesReactions.send]
+ */
+public suspend fun MessagesReactions.send(message: Message, name: String, type: MessageReactionType? = null, count: Int = 1) =
+    send(
+        messageSerial = message.serial,
+        name = name,
+        type = type,
+        count = count,
+    )
+
+/**
+ * @see [MessagesReactions.delete]
+ */
+public suspend fun MessagesReactions.delete(message: Message, name: String? = null, type: MessageReactionType? = null) =
+    delete(
+        messageSerial = message.serial,
+        name = name,
+        type = type,
+    )
+
+internal data class DefaultMessageReactionSummary(
+    override val messageSerial: String,
+    override val unique: Map<String, SummaryClientIdList> = mapOf(),
+    override val distinct: Map<String, SummaryClientIdList> = mapOf(),
+    override val multiple: Map<String, SummaryClientIdCounts> = mapOf(),
+) : MessageReactionsSummary
+
+internal data class DefaultMessageReactionRawEvent(
+    override val type: MessageReactionEventType,
+    override val timestamp: Long,
+    override val reaction: MessageReaction,
+) : MessageReactionRawEvent
+
+internal data class DefaultMessageReactionSummaryEvent(
+    override val summary: MessageReactionsSummary,
+    override val type: MessageReactionSummaryEventType = MessageReactionSummaryEventType.Summary,
+) : MessageReactionSummaryEvent
+
+internal data class DefaultMessageReaction(
+    override val messageSerial: String,
+    override val type: MessageReactionType,
+    override val name: String,
+    override val count: Int?,
+    override val clientId: String,
+) : MessageReaction
+
+internal class DefaultMessagesReactions(
+    private val chatApi: ChatApi,
+    private val roomId: String,
+    private val channel: Channel,
+    private val annotations: RealtimeAnnotations,
+    private val options: MessageOptions,
+    parentLogger: Logger,
+) : MessagesReactions {
+
+    private val logger = parentLogger.withContext("MessagesReactions")
+
+    private val reactionsScope = CoroutineScope(Dispatchers.Default.limitedParallelism(1) + SupervisorJob())
+
+    private val listeners: MutableList<MessagesReactions.Listener> = CopyOnWriteArrayList()
+    private val rawEventlisteners: MutableList<MessagesReactions.MessageRawReactionListener> = CopyOnWriteArrayList()
+
+    private val summaryEventBus = MutableSharedFlow<MessageReactionSummaryEvent>(
+        extraBufferCapacity = 1,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST,
+    )
+
+    private val rawEventBus = MutableSharedFlow<MessageReactionRawEvent>(
+        extraBufferCapacity = UNLIMITED,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST,
+    )
+
+    private val summarySubscription: Subscription
+    private var annotationSubscription: Subscription? = null
+
+    init {
+        reactionsScope.launch {
+            summaryEventBus.collect { summaryEvent ->
+                listeners.forEach {
+                    it.onReactionSummary(summaryEvent)
+                }
+            }
+        }
+
+        reactionsScope.launch {
+            rawEventBus.collect { rawEvent ->
+                rawEventlisteners.forEach {
+                    it.onRawReaction(rawEvent)
+                }
+            }
+        }
+
+        val messageSummaryListener = PubSubMessageListener {
+            internalMessageSummaryListener(it)
+        }
+
+        channel.subscribe(messageSummaryListener)
+        summarySubscription = Subscription { channel.unsubscribe(messageSummaryListener) }
+
+        if (options.rawMessageReactions) {
+            val annotationListener = RealtimeAnnotations.AnnotationListener {
+                internalAnnotationListener(it)
+            }
+            annotations.subscribe(annotationListener)
+            annotationSubscription = Subscription { annotations.unsubscribe(annotationListener) }
+        }
+    }
+
+    override suspend fun send(
+        messageSerial: String,
+        name: String,
+        type: MessageReactionType?,
+        count: Int,
+    ) {
+        val reactionType = type ?: options.defaultMessageReactionType
+
+        logger.trace(
+            "MessagesReactions.send();",
+            context = mapOf(
+                "messageSerial" to messageSerial,
+                "name" to name,
+                "type" to reactionType.name,
+                "count" to count.toString(),
+            ),
+        )
+
+        chatApi.sendMessageReaction(
+            roomId = roomId,
+            messageSerial = messageSerial,
+            type = reactionType,
+            name = name,
+            count = count,
+        )
+    }
+
+    override suspend fun delete(messageSerial: String, name: String?, type: MessageReactionType?) {
+        val reactionType = type ?: options.defaultMessageReactionType
+
+        logger.trace(
+            "MessagesReactions.delete();",
+            context = mapOf(
+                "messageSerial" to messageSerial,
+                "name" to (name ?: ""),
+                "type" to reactionType.name,
+            ),
+        )
+
+        if (reactionType != MessageReactionType.Unique && name == null) {
+            throw clientError("cannot delete reaction of type $type without a name")
+        }
+
+        chatApi.deleteMessageReaction(
+            roomId = roomId,
+            messageSerial = messageSerial,
+            type = reactionType,
+            name = name,
+        )
+    }
+
+    override fun subscribe(listener: MessagesReactions.Listener): Subscription {
+        logger.trace("MessagesReactions.subscribe()")
+        listeners.add(listener)
+        return Subscription {
+            logger.trace("MessagesReactions.unsubscribe()")
+            listeners.remove(listener)
+        }
+    }
+
+    override fun subscribeRaw(listener: MessagesReactions.MessageRawReactionListener): Subscription {
+        logger.trace("MessagesReactions.subscribeRaw()")
+        rawEventlisteners.add(listener)
+        return Subscription {
+            logger.trace("MessagesReactions.unsubscribeRaw()")
+            rawEventlisteners.remove(listener)
+        }
+    }
+
+    fun dispose() {
+        summarySubscription.unsubscribe()
+        annotationSubscription?.unsubscribe()
+        reactionsScope.cancel()
+    }
+
+    private fun internalMessageSummaryListener(message: PubSubMessage) {
+        logger.trace("MessagesReactions.internalSummaryListener();", context = mapOf("message" to message.toString()))
+
+        // only process summary events with the serial
+        if (message.action !== MessageAction.MESSAGE_SUMMARY || message.serial == null) {
+            message.serial ?: logger.warn(
+                "DefaultMessageReactions.internalSummaryListener(); received summary without serial",
+                context = mapOf("message" to message.toString()),
+            )
+
+            return
+        }
+
+        if (message.summary == null) {
+            // This means the summary is now empty, which is valid.
+            // Happens when there are no reactions such as after deleting the last reaction.
+            summaryEventBus.tryEmit(
+                DefaultMessageReactionSummaryEvent(
+                    DefaultMessageReactionSummary(
+                        messageSerial = message.serial,
+                        unique = emptyMap(),
+                        distinct = emptyMap(),
+                        multiple = emptyMap(),
+                    ),
+                ),
+            )
+            return
+        }
+
+        val unique = Summary.asSummaryUniqueV1(message.summary.get(MessageReactionType.Unique.type) ?: JsonObject())
+        val distinct = Summary.asSummaryDistinctV1(message.summary.get(MessageReactionType.Distinct.type) ?: JsonObject())
+        val multiple = Summary.asSummaryMultipleV1(message.summary.get(MessageReactionType.Multiple.type) ?: JsonObject())
+
+        summaryEventBus.tryEmit(
+            DefaultMessageReactionSummaryEvent(
+                DefaultMessageReactionSummary(
+                    messageSerial = message.serial,
+                    unique = unique,
+                    distinct = distinct,
+                    multiple = multiple,
+                ),
+            ),
+        )
+    }
+
+    @Suppress("ReturnCount")
+    private fun internalAnnotationListener(annotation: Annotation) {
+        logger.trace("MessagesReactions.internalAnnotationListener();", context = mapOf("annotation" to annotation.toString()))
+
+        if (annotation.messageSerial == null) {
+            logger.warn(
+                "MessagesReactions.internalAnnotationListener(); received event with missing messageSerial",
+                context = mapOf("annotation" to annotation.toString()),
+            )
+            return
+        }
+
+        val reactionType = MessageReactionType.tryFind(annotation.type) ?: run {
+            logger.debug(
+                "DefaultMessageReactions.internalAnnotationListener(); received event with unknown type",
+                context = mapOf("annotation" to annotation.toString()),
+            )
+            return
+        }
+
+        val action = annotation.action ?: run {
+            logger.debug("DefaultMessageReactions.internalAnnotationListener(); received event with unknown action")
+            return
+        }
+
+        val eventType = when (action) {
+            AnnotationAction.ANNOTATION_CREATE -> MessageReactionEventType.Create
+            AnnotationAction.ANNOTATION_DELETE -> MessageReactionEventType.Delete
+        }
+
+        val name = annotation.name ?: run {
+            if (eventType === MessageReactionEventType.Delete && reactionType === MessageReactionType.Unique) {
+                // deletes of type unique are allowed to have no data
+                ""
+            } else {
+                return
+            }
+        }
+
+        val count = annotation.count ?: (
+            if (eventType === MessageReactionEventType.Create && reactionType === MessageReactionType.Multiple) {
+                1
+            } else {
+                null
+            }
+            )
+
+        val reactionEvent = DefaultMessageReactionRawEvent(
+            type = eventType,
+            timestamp = annotation.timestamp,
+            reaction = DefaultMessageReaction(
+                messageSerial = annotation.messageSerial,
+                type = reactionType,
+                name = name,
+                clientId = annotation.clientId,
+                count = count,
+            ),
+        )
+
+        rawEventBus.tryEmit(reactionEvent)
+    }
+}

--- a/chat-android/src/main/java/com/ably/chat/MessagesReactions.kt
+++ b/chat-android/src/main/java/com/ably/chat/MessagesReactions.kt
@@ -337,6 +337,9 @@ internal class DefaultMessagesReactions(
         type: MessageReactionType?,
         count: Int,
     ) {
+        // CHA-MR4a1
+        checkMessageSerialIsNotEmpty(messageSerial)
+
         val reactionType = type ?: options.defaultMessageReactionType
 
         logger.trace(
@@ -359,6 +362,9 @@ internal class DefaultMessagesReactions(
     }
 
     override suspend fun delete(messageSerial: String, name: String?, type: MessageReactionType?) {
+        // CHA-MR11a1
+        checkMessageSerialIsNotEmpty(messageSerial)
+
         val reactionType = type ?: options.defaultMessageReactionType
 
         logger.trace(
@@ -393,6 +399,11 @@ internal class DefaultMessagesReactions(
 
     override fun subscribeRaw(listener: MessagesReactions.MessageRawReactionListener): Subscription {
         logger.trace("MessagesReactions.subscribeRaw()")
+
+        if (!options.rawMessageReactions) {
+            throw clientError("raw message reactions are not enabled")
+        }
+
         rawEventlisteners.add(listener)
         return Subscription {
             logger.trace("MessagesReactions.unsubscribeRaw()")
@@ -404,6 +415,12 @@ internal class DefaultMessagesReactions(
         summarySubscription.unsubscribe()
         annotationSubscription?.unsubscribe()
         reactionsScope.cancel()
+    }
+
+    private fun checkMessageSerialIsNotEmpty(messageSerial: String) {
+        if (messageSerial.isEmpty()) {
+            throw clientError("messageSerial cannot be empty")
+        }
     }
 
     private fun internalMessageSummaryListener(message: PubSubMessage) {

--- a/chat-android/src/main/java/com/ably/chat/RoomOptions.kt
+++ b/chat-android/src/main/java/com/ably/chat/RoomOptions.kt
@@ -251,7 +251,7 @@ internal fun RoomOptions.channelOptions(): ChannelOptions {
             params = mapOf("occupancy" to "metrics")
         }
 
-        if (messages.rawMessageReactions) {
+        if (messages.rawMessageReactions) { // CHA-MR9a
             channelModes.add(ChannelMode.annotation_subscribe)
         }
 

--- a/chat-android/src/main/java/com/ably/chat/RoomOptions.kt
+++ b/chat-android/src/main/java/com/ably/chat/RoomOptions.kt
@@ -15,25 +15,30 @@ public interface RoomOptions {
      * use `rooms.get("ROOM_NAME") { presence() }` to enable presence with default options.
      * @defaultValue undefined
      */
-    public val presence: PresenceOptions?
+    public val presence: PresenceOptions
 
     /**
      * The typing options for the room. To enable typing in the room, set this property. You may use
      * `rooms.get("ROOM_NAME") { typing() }`to enable typing with default options.
      */
-    public val typing: TypingOptions?
+    public val typing: TypingOptions
 
     /**
      * The reactions options for the room. To enable reactions in the room, set this property. You may use
      * `rooms.get("ROOM_NAME") { reactions() }` to enable reactions with default options.
      */
-    public val reactions: RoomReactionsOptions?
+    public val reactions: RoomReactionsOptions
 
     /**
      * The occupancy options for the room. To enable occupancy in the room, set this property. You may use
      * `rooms.get("ROOM_NAME") { occupancy() }` to enable occupancy with default options.
      */
-    public val occupancy: OccupancyOptions?
+    public val occupancy: OccupancyOptions
+
+    /**
+     * The message options for the room.
+     */
+    public val messages: MessageOptions
 }
 
 /**
@@ -83,12 +88,39 @@ public interface OccupancyOptions {
     public val enableEvents: Boolean
 }
 
+/**
+ * Represents the message options for a chat room.
+ */
+public interface MessageOptions {
+    /**
+     * Whether to enable receiving raw individual message reactions from the
+     * realtime channel. Set to true if subscribing to raw message reactions.
+     *
+     * Note reaction summaries (aggregates) are always available regardless of
+     * this setting.
+     *
+     * @defaultValue false
+     */
+    public val rawMessageReactions: Boolean
+
+    /**
+     * The default message reaction type to use for sending message reactions.
+     *
+     * Any message reaction type can be sent regardless of this setting by specifying the `type` parameter
+     * in the [MessagesReactions.send] method.
+     *
+     * @defaultValue [MessageReactionType.Distinct]
+     */
+    public val defaultMessageReactionType: MessageReactionType
+}
+
 @ChatDsl
 public class MutableRoomOptions : RoomOptions {
     override var presence: MutablePresenceOptions = MutablePresenceOptions()
     override var typing: MutableTypingOptions = MutableTypingOptions()
     override var reactions: MutableRoomReactionsOptions = MutableRoomReactionsOptions()
     override var occupancy: MutableOccupancyOptions = MutableOccupancyOptions()
+    override var messages: MutableMessageOptions = MutableMessageOptions()
 }
 
 @ChatDsl
@@ -107,6 +139,12 @@ public class MutableRoomReactionsOptions : RoomReactionsOptions
 @ChatDsl
 public class MutableOccupancyOptions : OccupancyOptions {
     override var enableEvents: Boolean = false // CHA-O6c
+}
+
+@ChatDsl
+public class MutableMessageOptions : MessageOptions {
+    override var rawMessageReactions: Boolean = false
+    override var defaultMessageReactionType: MessageReactionType = MessageReactionType.Distinct
 }
 
 internal fun buildRoomOptions(init: (MutableRoomOptions.() -> Unit)? = null): RoomOptions =
@@ -128,11 +166,16 @@ public fun MutableRoomOptions.occupancy(init: MutableOccupancyOptions.() -> Unit
     this.occupancy = MutableOccupancyOptions().apply(init)
 }
 
+public fun MutableRoomOptions.messages(init: MutableMessageOptions.() -> Unit = {}) {
+    this.messages = MutableMessageOptions().apply(init)
+}
+
 internal data class EquatableRoomOptions(
-    override val presence: PresenceOptions? = null,
-    override val typing: TypingOptions? = null,
-    override val reactions: RoomReactionsOptions? = null,
-    override val occupancy: OccupancyOptions? = null,
+    override val presence: PresenceOptions,
+    override val typing: TypingOptions,
+    override val reactions: RoomReactionsOptions,
+    override val occupancy: OccupancyOptions,
+    override val messages: MessageOptions,
 ) : RoomOptions
 
 internal data class EquatablePresenceOptions(
@@ -147,6 +190,11 @@ internal data class EquatableOccupancyOptions(
     override val enableEvents: Boolean,
 ) : OccupancyOptions
 
+internal data class EquatableMessageOptions(
+    override val rawMessageReactions: Boolean,
+    override val defaultMessageReactionType: MessageReactionType,
+) : MessageOptions
+
 internal data object EquatableRoomReactionsOptions : RoomReactionsOptions
 
 internal fun MutableRoomOptions.asEquatable() = EquatableRoomOptions(
@@ -154,6 +202,7 @@ internal fun MutableRoomOptions.asEquatable() = EquatableRoomOptions(
     typing = typing.asEquatable(),
     reactions = EquatableRoomReactionsOptions,
     occupancy = occupancy.asEquatable(),
+    messages = messages.asEquatable(),
 )
 
 internal fun MutablePresenceOptions.asEquatable() = EquatablePresenceOptions(
@@ -168,16 +217,19 @@ internal fun MutableOccupancyOptions.asEquatable() = EquatableOccupancyOptions(
     enableEvents = enableEvents,
 )
 
+internal fun MutableMessageOptions.asEquatable() = EquatableMessageOptions(
+    rawMessageReactions = rawMessageReactions,
+    defaultMessageReactionType = defaultMessageReactionType,
+)
+
 /**
  * Throws AblyException for invalid room configuration.
  * Spec: CHA-RC2a
  */
 internal fun RoomOptions.validateRoomOptions(logger: Logger) {
-    typing?.let {
-        if (it.heartbeatThrottle.inWholeMilliseconds <= 0) {
-            logger.error("Typing heartbeatThrottle must be greater than 0, found ${it.heartbeatThrottle}")
-            throw ablyException("Typing heartbeatThrottle must be greater than 0", ErrorCode.InvalidRequestBody)
-        }
+    if (typing.heartbeatThrottle.inWholeMilliseconds <= 0) {
+        logger.error("Typing heartbeatThrottle must be greater than 0, found ${typing.heartbeatThrottle}")
+        throw ablyException("Typing heartbeatThrottle must be greater than 0", ErrorCode.InvalidRequestBody)
     }
 }
 
@@ -189,15 +241,20 @@ internal fun RoomOptions.validateRoomOptions(logger: Logger) {
  */
 internal fun RoomOptions.channelOptions(): ChannelOptions {
     return ChatChannelOptions {
-        presence?.let {
-            if (!it.enableEvents) { // CHA-PR9c2
-                modes = arrayOf(ChannelMode.publish, ChannelMode.subscribe, ChannelMode.presence)
-            }
+        val channelModes = mutableSetOf(ChannelMode.publish, ChannelMode.subscribe, ChannelMode.presence, ChannelMode.annotation_publish)
+
+        if (presence.enableEvents) { // CHA-PR9c2
+            channelModes.add(ChannelMode.presence_subscribe)
         }
-        occupancy?.let { // CHA-O6b
-            if (it.enableEvents) { // CHA-O6a
-                params = mapOf("occupancy" to "metrics")
-            }
+
+        if (occupancy.enableEvents) { // CHA-O6a
+            params = mapOf("occupancy" to "metrics")
         }
+
+        if (messages.rawMessageReactions) {
+            channelModes.add(ChannelMode.annotation_subscribe)
+        }
+
+        modes = channelModes.toTypedArray()
     }
 }

--- a/chat-android/src/test/java/com/ably/chat/MessageTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/MessageTest.kt
@@ -1,0 +1,196 @@
+package com.ably.chat
+
+import com.google.gson.JsonObject
+import io.ably.lib.types.AblyException
+import io.ably.lib.types.MessageAction
+import io.ably.lib.types.SummaryClientIdCounts
+import io.ably.lib.types.SummaryClientIdList
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+class MessageTest {
+
+    /**
+     * Spec: CHA-M11c
+     */
+    @Test
+    fun `with should return the same message if event version is less than or equal to the current message version`() {
+        val initialMessage = createMessage(
+            text = "Hello",
+            serial = "123",
+            version = "2",
+            reactions = DefaultMessageReactions(
+                mapOf("heart" to SummaryClientIdList(1, listOf("user1"))),
+            ),
+        )
+        val eventMessage = createMessage(
+            text = "Hello",
+            serial = "123",
+            version = "1",
+            action = MessageAction.MESSAGE_UPDATE,
+        )
+        val event = DefaultMessageEvent(
+            type = MessageEventType.Updated,
+            message = eventMessage,
+        )
+
+        val result = initialMessage.with(event)
+
+        assertSame(initialMessage, result)
+    }
+
+    /**
+     * Spec: CHA-M11d
+     */
+    @Test
+    fun `with should update the message with the event if version is greater`() {
+        val initialMessage = createMessage(
+            text = "Hello",
+            serial = "123",
+            version = "1",
+        )
+        val eventMessage = createMessage(
+            text = "Updated Hello",
+            serial = "123",
+            version = "2",
+        )
+        val event = DefaultMessageEvent(
+            type = MessageEventType.Updated,
+            message = eventMessage,
+        )
+
+        val result = initialMessage.with(event)
+
+        assertEquals(eventMessage.text, result.text)
+    }
+
+    /**
+     * Spec: CHA-M11b
+     */
+    @Test
+    fun `with should throw an exception if message serial does not match`() {
+        val initialMessage = createMessage(
+            text = "Hello",
+            serial = "456",
+            version = "1",
+        )
+        val eventMessage = createMessage(
+            text = "Hello",
+            serial = "457",
+            version = "1",
+        )
+
+        val event = DefaultMessageEvent(
+            type = MessageEventType.Updated,
+            message = eventMessage,
+        )
+
+        val exception = assertThrows(AblyException::class.java) {
+            initialMessage.with(event)
+        }
+        assertEquals(exception.errorInfo.code, 40_000)
+        assertEquals(exception.errorInfo.statusCode, 400)
+    }
+
+    /**
+     * Spec: CHA-M11g
+     */
+    @Test
+    fun `with should update the message reactions from a MessageReactionSummaryEvent`() {
+        val initialMessage = createMessage(
+            text = "Hello",
+            serial = "123",
+            version = "1",
+            reactions = DefaultMessageReactions(),
+        )
+        val summary = DefaultMessageReactionSummary(
+            messageSerial = "123",
+            unique = mapOf("like" to SummaryClientIdList(2, listOf("user1", "user2"))),
+            distinct = mapOf("like" to SummaryClientIdList(1, listOf("user1"))),
+            multiple = mapOf("like" to SummaryClientIdCounts(1, mapOf("user1" to 1))),
+        )
+
+        val event = DefaultMessageReactionSummaryEvent(summary = summary)
+
+        assertEquals(
+            initialMessage.copy(
+                reactions = DefaultMessageReactions(
+                    unique = summary.unique,
+                    distinct = summary.distinct,
+                    multiple = summary.multiple,
+                ),
+            ),
+            initialMessage.with(event),
+        )
+    }
+
+    /**
+     * Spec: CHA-M11e
+     */
+    @Test
+    fun `with should throw an exception when applying a MessageReactionSummaryEvent with a different serial`() {
+        val initialMessage = createMessage(
+            text = "Hello",
+            serial = "123",
+            version = "1",
+            reactions = DefaultMessageReactions(),
+        )
+        val summary = DefaultMessageReactionSummary(
+            messageSerial = "456",
+        )
+
+        val event = DefaultMessageReactionSummaryEvent(summary = summary)
+
+        val exception = assertThrows(AblyException::class.java) {
+            initialMessage.with(event)
+        }
+        assertEquals(exception.errorInfo.code, 40_000)
+        assertEquals(exception.errorInfo.statusCode, 400)
+    }
+
+    /**
+     * CHA-M11a
+     */
+    @Test
+    fun `with should throw an exception when applying with create type`() {
+        val initialMessage = createMessage(
+            text = "Hello",
+            serial = "123",
+            version = "1",
+            reactions = DefaultMessageReactions(),
+        )
+        val summary = DefaultMessageReactionSummary(
+            messageSerial = "456",
+        )
+
+        val event = DefaultMessageReactionSummaryEvent(summary = summary)
+
+        val exception = assertThrows(AblyException::class.java) {
+            initialMessage.with(event)
+        }
+        assertEquals(exception.errorInfo.code, 40_000)
+        assertEquals(exception.errorInfo.statusCode, 400)
+    }
+}
+
+private fun createMessage(
+    text: String,
+    serial: String,
+    version: String,
+    action: MessageAction = MessageAction.MESSAGE_CREATE,
+    reactions: MessageReactions = DefaultMessageReactions(),
+) = DefaultMessage(
+    text = text,
+    serial = serial,
+    version = version,
+    clientId = "client1",
+    roomId = "room1",
+    createdAt = System.currentTimeMillis(),
+    metadata = JsonObject(),
+    headers = mapOf(),
+    action = action,
+    timestamp = System.currentTimeMillis(),
+    reactions = reactions,
+)

--- a/chat-android/src/test/java/com/ably/chat/MessagesReactionsTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/MessagesReactionsTest.kt
@@ -1,0 +1,161 @@
+package com.ably.chat
+
+import com.ably.chat.room.createMockChatApi
+import com.ably.chat.room.createMockRealtimeClient
+import com.google.gson.JsonArray
+import com.google.gson.JsonObject
+import io.ably.lib.realtime.RealtimeAnnotations
+import io.ably.lib.realtime.buildRealtimeChannel
+import io.ably.lib.types.Annotation
+import io.ably.lib.types.AnnotationAction
+import io.ably.lib.types.MessageAction
+import io.ably.lib.types.Summary
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.spyk
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+class MessagesReactionsTest {
+    private val realtimeClient = createMockRealtimeClient()
+    private val chatApi = createMockChatApi(realtimeClient)
+    private val channel = spyk(buildRealtimeChannel("room1::\$chat"))
+    private val annotations = spyk(channel.annotations)
+
+    @Before
+    fun setUp() {
+        coEvery { chatApi.sendMessageReaction(any(), any(), any(), any()) } returns Unit
+    }
+
+    /**
+     * Spec: CHA-MR4, CHA-MR4b2
+     */
+    @Test
+    fun `should propagate reactions type from options`() = runTest {
+        val messagesReactions = createMessagesReaction()
+        messagesReactions.send("messageSerial", "heart")
+        coVerify { chatApi.sendMessageReaction("room1", "messageSerial", MessageReactionType.Distinct, "heart") }
+    }
+
+    /**
+     * Spec: CHA-MR4
+     */
+    @Test
+    fun `specified reactions type should take precedent over type from options`() = runTest {
+        val messagesReactions = createMessagesReaction()
+        messagesReactions.send("messageSerial", "heart", MessageReactionType.Multiple)
+        coVerify { chatApi.sendMessageReaction("room1", "messageSerial", MessageReactionType.Multiple, "heart") }
+    }
+
+    /**
+     * Spec: CHA-MR6
+     */
+    @Test
+    fun `should be able to subscribe to incoming summaries`() = runTest {
+        val pubSubMessageListenerSlot = slot<PubSubMessageListener>()
+        every { channel.subscribe(capture(pubSubMessageListenerSlot)) } returns mockk()
+        val deferredValue = CompletableDeferred<MessageReactionSummaryEvent>()
+
+        val messagesReactions = createMessagesReaction()
+
+        messagesReactions.subscribe {
+            deferredValue.complete(it)
+        }
+
+        pubSubMessageListenerSlot.captured.onMessage(
+            PubSubMessage().apply {
+                serial = "abcdefghij@1672531200000-123"
+                timestamp = 1000L
+                createdAt = 1000L
+                summary = Summary(
+                    mapOf(
+                        "reaction:distinct.v1" to JsonObject().apply {
+                            add(
+                                "heart",
+                                JsonObject().apply {
+                                    addProperty("total", 1)
+                                    add(
+                                        "clientIds",
+                                        JsonArray().apply {
+                                            add("clientId")
+                                        },
+                                    )
+                                },
+                            )
+                        },
+                    ),
+                )
+                action = MessageAction.MESSAGE_SUMMARY
+            },
+        )
+
+        val event = deferredValue.await()
+
+        assertEquals(MessageReactionSummaryEventType.Summary, event.type)
+        assertEquals("abcdefghij@1672531200000-123", event.summary.messageSerial)
+        assertEquals(1, event.summary.distinct["heart"]?.total)
+        assertEquals(listOf("clientId"), event.summary.distinct["heart"]?.clientIds)
+    }
+
+    /**
+     * Spec: CHA-MR7
+     */
+    @Test
+    fun `should be able to subscribe to raw events`() = runTest {
+        val annotationsListenerSlot = slot<RealtimeAnnotations.AnnotationListener>()
+
+        every { annotations.subscribe(capture(annotationsListenerSlot)) } returns mockk()
+        val deferredValue = CompletableDeferred<MessageReactionRawEvent>()
+
+        val messagesReactions = createMessagesReaction(
+            MutableMessageOptions().apply {
+                rawMessageReactions = true
+            },
+        )
+
+        messagesReactions.subscribeRaw {
+            deferredValue.complete(it)
+        }
+
+        annotationsListenerSlot.captured.onAnnotation(
+            Annotation().apply {
+                serial = "abcdefghij@1672531200000-456"
+                messageSerial = "abcdefghij@1672531200000-123"
+                timestamp = 1000L
+                action = AnnotationAction.ANNOTATION_CREATE
+                type = "reaction:distinct.v1"
+                name = "heart"
+                clientId = "clientId"
+            },
+        )
+
+        val event = deferredValue.await()
+
+        assertEquals(MessageReactionEventType.Create, event.type)
+        assertEquals(
+            DefaultMessageReaction(
+                messageSerial = "abcdefghij@1672531200000-123",
+                name = "heart",
+                clientId = "clientId",
+                type = MessageReactionType.Distinct,
+                count = null,
+            ),
+            event.reaction,
+        )
+    }
+
+    private fun createMessagesReaction(options: MessageOptions = MutableMessageOptions()) = DefaultMessagesReactions(
+        chatApi = chatApi,
+        roomId = "room1",
+        channel = channel,
+        annotations = annotations,
+        options = options,
+        parentLogger = EmptyLogger(DefaultLogContext("TEST")),
+    )
+}

--- a/chat-android/src/test/java/com/ably/chat/MessagesReactionsTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/MessagesReactionsTest.kt
@@ -164,7 +164,6 @@ class MessagesReactionsTest {
             runBlocking {
                 messagesReactions.send("", "heart")
             }
-
         }
         assertEquals(exception.errorInfo.code, 40_000)
         assertEquals(exception.errorInfo.statusCode, 400)
@@ -181,7 +180,6 @@ class MessagesReactionsTest {
             runBlocking {
                 messagesReactions.delete("", "heart")
             }
-
         }
         assertEquals(exception.errorInfo.code, 40_000)
         assertEquals(exception.errorInfo.statusCode, 400)
@@ -191,7 +189,7 @@ class MessagesReactionsTest {
      * Spec: CHA-MR7a
      */
     @Test
-    fun `subscribeRaw should throw an exception if messageSerial is empty string`() = runTest {
+    fun `subscribeRaw should throw an exception if rawMessageReactions is not enabled`() = runTest {
         val messagesReactions = createMessagesReaction(
             MutableMessageOptions().apply {
                 rawMessageReactions = false
@@ -199,7 +197,56 @@ class MessagesReactionsTest {
         )
 
         val exception = assertThrows(AblyException::class.java) {
-            messagesReactions.subscribeRaw {  }
+            messagesReactions.subscribeRaw { }
+        }
+        assertEquals(exception.errorInfo.code, 40_000)
+        assertEquals(exception.errorInfo.statusCode, 400)
+    }
+
+    /**
+     * Spec: CHA-MR4b3
+     */
+    @Test
+    fun `send should throw exception if count specified for any type other than multiple`() = runTest {
+        val messagesReactions = createMessagesReaction()
+
+        val exception = assertThrows(AblyException::class.java) {
+            runBlocking {
+                messagesReactions.send("abcdefghij@1672531200000-123", "heart", count = 3)
+            }
+        }
+        assertEquals(exception.errorInfo.code, 40_000)
+        assertEquals(exception.errorInfo.statusCode, 400)
+    }
+
+    /**
+     * Spec: CHA-MR4b3
+     */
+    @Test
+    fun `send should throw exception if count is not positive`() = runTest {
+        val messagesReactions = createMessagesReaction()
+
+        messagesReactions.send("abcdefghij@1672531200000-123", "heart", MessageReactionType.Multiple, count = 1)
+        val exception = assertThrows(AblyException::class.java) {
+            runBlocking {
+                messagesReactions.send("abcdefghij@1672531200000-123", "heart", MessageReactionType.Multiple, count = 0)
+            }
+        }
+        assertEquals(exception.errorInfo.code, 40_000)
+        assertEquals(exception.errorInfo.statusCode, 400)
+    }
+
+    /**
+     * Spec: CHA-MR4b3
+     */
+    @Test
+    fun `send should throw exception if reaction name is empty`() = runTest {
+        val messagesReactions = createMessagesReaction()
+
+        val exception = assertThrows(AblyException::class.java) {
+            runBlocking {
+                messagesReactions.send("abcdefghij@1672531200000-123", "")
+            }
         }
         assertEquals(exception.errorInfo.code, 40_000)
         assertEquals(exception.errorInfo.statusCode, 400)

--- a/chat-android/src/test/java/com/ably/chat/integration/MessageReactionsIntegrationTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/integration/MessageReactionsIntegrationTest.kt
@@ -1,0 +1,157 @@
+package com.ably.chat.integration
+
+import com.ably.chat.MessageReactionSummaryEvent
+import com.ably.chat.MessageReactionType
+import com.ably.chat.MessagesReactions
+import com.ably.chat.Room
+import com.ably.chat.Subscription
+import com.ably.chat.get
+import com.ably.chat.messages
+import java.util.UUID
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.BeforeClass
+import org.junit.Test
+
+class MessageReactionsIntegrationTest {
+
+    /**
+     * Spec: CHA-MR4, CHA-MR7
+     */
+    @Test
+    fun `should correctly send message reaction`() = runTest {
+        val chatClient = sandbox.createSandboxChatClient()
+        val roomId = UUID.randomUUID().toString()
+        val room = chatClient.rooms.get(roomId) {
+            messages {
+                rawMessageReactions = true
+            }
+        }
+
+        room.attach()
+
+        val message = room.messages.send("test")
+
+        val receiveReactionsDeferred = waitForRawReactions(room, 4)
+
+        listOf("like", "smile", "like", "heart").forEach { reactionName ->
+            room.messages.reactions.send(message.serial, reactionName)
+        }
+
+        val receivedReactions = receiveReactionsDeferred.await()
+
+        assertEquals(listOf("like", "smile", "like", "heart"), receivedReactions)
+    }
+
+    /**
+     * Spec: CHA-MR11, CHA-MR6
+     */
+    @Test
+    fun `should correctly delete message reaction`() = runTest {
+        val chatClient = sandbox.createSandboxChatClient()
+        val roomId = UUID.randomUUID().toString()
+        val room = chatClient.rooms.get(roomId)
+        room.attach()
+        val message = room.messages.send("test")
+
+        val event1Deferred = room.messages.reactions.subscribeOnce()
+        room.messages.reactions.send(message.serial, "like")
+        val event1 = event1Deferred.await()
+        assertEquals(message.serial, event1.summary.messageSerial)
+        assertEquals(1, event1.summary.distinct["like"]?.total)
+        assertEquals(listOf("sandbox-client"), event1.summary.distinct["like"]?.clientIds)
+
+        val event2Deferred = room.messages.reactions.subscribeOnce()
+        room.messages.reactions.delete(message.serial, "like")
+        val event2 = event2Deferred.await()
+        assertEquals(message.serial, event2.summary.messageSerial)
+        assertEquals(null, event2.summary.distinct["like"])
+    }
+
+    /**
+     * Spec: CHA-MR11, CHA-MR6
+     */
+    @Test
+    fun `should delete with multiple summary type`() = runTest {
+        val chatClient = sandbox.createSandboxChatClient()
+        val roomId = UUID.randomUUID().toString()
+        val room = chatClient.rooms.get(roomId)
+        room.attach()
+        val message = room.messages.send("test")
+
+        val event1Deferred = room.messages.reactions.subscribeOnce()
+        room.messages.reactions.send(message.serial, "like", MessageReactionType.Multiple)
+        val event1 = event1Deferred.await()
+        assertEquals(1, event1.summary.multiple["like"]?.total)
+
+        val event2 = room.messages.reactions.subscribeOnce()
+        room.messages.reactions.send(message.serial, "like", MessageReactionType.Multiple, 2)
+        assertEquals(3, event2.await().summary.multiple["like"]?.total)
+
+        val event3Deferred = room.messages.reactions.subscribeOnce()
+        room.messages.reactions.delete(message.serial, "like", MessageReactionType.Multiple)
+        val event3 = event3Deferred.await()
+        assertEquals(message.serial, event3.summary.messageSerial)
+        assertEquals(null, event3.summary.multiple["like"])
+    }
+
+    /**
+     * Spec: CHA-MR5
+     */
+    @Test
+    fun `should use unique summary type`() = runTest {
+        val chatClient = sandbox.createSandboxChatClient()
+        val roomId = UUID.randomUUID().toString()
+        val room = chatClient.rooms.get(roomId) {
+            messages {
+                defaultMessageReactionType = MessageReactionType.Unique
+            }
+        }
+
+        room.attach()
+
+        val message = room.messages.send("test")
+
+        val event1Deferred = room.messages.reactions.subscribeOnce()
+        room.messages.reactions.send(message.serial, "like")
+        val event1 = event1Deferred.await()
+        assertEquals(message.serial, event1.summary.messageSerial)
+        assertEquals(1, event1.summary.unique["like"]?.total)
+        assertEquals(listOf("sandbox-client"), event1.summary.unique["like"]?.clientIds)
+    }
+
+    private fun waitForRawReactions(room: Room, size: Int): CompletableDeferred<List<String>> {
+        val messageEvent = CompletableDeferred<List<String>>()
+        val receivedReactions = mutableListOf<String>()
+        lateinit var subscription: Subscription
+        subscription = room.messages.reactions.subscribeRaw { event ->
+            receivedReactions.add(event.reaction.name)
+            if (receivedReactions.size == size) {
+                subscription.unsubscribe()
+                messageEvent.complete(receivedReactions)
+            }
+        }
+        return messageEvent
+    }
+
+    companion object {
+        private lateinit var sandbox: Sandbox
+
+        @JvmStatic
+        @BeforeClass
+        fun setUp() = runTest {
+            sandbox = Sandbox.createInstance()
+        }
+    }
+}
+
+private fun MessagesReactions.subscribeOnce(): CompletableDeferred<MessageReactionSummaryEvent> {
+    val deferredEvent = CompletableDeferred<MessageReactionSummaryEvent>()
+    lateinit var subscription: Subscription
+    subscription = subscribe { event ->
+        subscription.unsubscribe()
+        deferredEvent.complete(event)
+    }
+    return deferredEvent
+}

--- a/chat-android/src/test/java/com/ably/chat/room/RoomFeatureSharedChannelTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/room/RoomFeatureSharedChannelTest.kt
@@ -65,13 +65,22 @@ class RoomFeatureSharedChannelTest {
 
         // Create room with default roomOptions
         var room = createTestRoom(realtimeClient = mockRealtimeClient)
-        Assert.assertTrue(room.options.presence!!.enableEvents)
-        Assert.assertFalse(room.options.occupancy!!.enableEvents)
+        Assert.assertTrue(room.options.presence.enableEvents)
+        Assert.assertFalse(room.options.occupancy.enableEvents)
 
         Assert.assertEquals(1, capturedChannelOptions.size)
 
         // Check for empty presence modes
-        Assert.assertNull(capturedChannelOptions[0].modes)
+        Assert.assertArrayEquals(
+            arrayOf(
+                ChannelMode.publish,
+                ChannelMode.subscribe,
+                ChannelMode.presence,
+                ChannelMode.annotation_publish,
+                ChannelMode.presence_subscribe,
+            ),
+            capturedChannelOptions[0].modes,
+        )
         // Check for empty params since occupancy subscribe is disabled by default
         Assert.assertNull(capturedChannelOptions[0].params)
 
@@ -89,16 +98,17 @@ class RoomFeatureSharedChannelTest {
             "clientId",
             createMockLogger(),
         )
-        Assert.assertFalse(room.options.presence!!.enableEvents)
-        Assert.assertTrue(room.options.occupancy!!.enableEvents)
+        Assert.assertFalse(room.options.presence.enableEvents)
+        Assert.assertTrue(room.options.occupancy.enableEvents)
 
         Assert.assertEquals(1, capturedChannelOptions.size)
 
         // CHA-PR9c2 - Check for set presence modes, presence_subscribe flag doesn't exist
-        Assert.assertEquals(3, capturedChannelOptions[0].modes.size)
+        Assert.assertEquals(4, capturedChannelOptions[0].modes.size)
         Assert.assertEquals(ChannelMode.publish, capturedChannelOptions[0].modes[0])
         Assert.assertEquals(ChannelMode.subscribe, capturedChannelOptions[0].modes[1])
         Assert.assertEquals(ChannelMode.presence, capturedChannelOptions[0].modes[2])
+        Assert.assertEquals(ChannelMode.annotation_publish, capturedChannelOptions[0].modes[3])
 
         // CHA-O6a - Check if occupancy matrix is set
         Assert.assertEquals("metrics", capturedChannelOptions[0].params["occupancy"])

--- a/chat-android/src/test/java/com/ably/chat/room/lifecycle/MonitoringTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/room/lifecycle/MonitoringTest.kt
@@ -47,8 +47,9 @@ class MonitoringTest {
     @Before
     fun setUp() {
         val sharedChannel = createMockRealtimeChannel()
-        every { sharedChannel.javaChannel.on(capture(channelStateListeners)) } returns mockk()
-        every { sharedChannel.javaChannel.off(any()) } returns Unit
+        val javaChannel = sharedChannel.javaChannel
+        every { javaChannel.on(capture(channelStateListeners)) } returns mockk()
+        every { javaChannel.off(any()) } returns Unit
 
         val realtimeClient = createMockRealtimeClient()
         every {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 # https://docs.gradle.org/current/userguide/platforms.html#sub::toml-dependencies-format
 
 [versions]
-ably = "1.2.50"
+ably = "1.2.53"
 junit = "4.13.2"
 agp = "8.5.2"
 detekt = "1.23.6"


### PR DESCRIPTION
Introduced support for message reactions in the chat API, enabling the addition, deletion, and subscription to reactions. Implemented related interfaces, listeners, data types, and integration tests to ensure proper functionality and integration with messages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced support for message reactions, allowing users to add, delete, and view reactions on chat messages.
  - Added configuration options for message reactions at the room level, including reaction types and raw event subscriptions.
  - Enabled real-time subscriptions to reaction summaries and raw reaction events for enhanced chat interactivity.

- **Bug Fixes**
  - Improved validation and error handling for message reaction operations.

- **Tests**
  - Added comprehensive unit and integration tests to ensure correct behavior of message reactions and event subscriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->