### PR TITLE
[ECO-5343] refactor!: unify event and type naming in chat API

### DIFF
--- a/chat-android/src/main/java/com/ably/chat/ChatApi.kt
+++ b/chat-android/src/main/java/com/ably/chat/ChatApi.kt
@@ -168,11 +168,11 @@ internal class ChatApi(
     /**
      * return occupancy for specified room
      */
-    suspend fun getOccupancy(roomId: String): OccupancyEvent {
+    suspend fun getOccupancy(roomId: String): OccupancyData {
         logger.trace("getOccupancy();", context = mapOf("roomId" to roomId))
         return this.makeAuthorizedRequest("/chat/$CHAT_API_PROTOCOL_VERSION/rooms/$roomId/occupancy", HttpMethod.Get)?.let {
             logger.debug("getOccupancy();", context = mapOf("roomId" to roomId, "response" to it.toString()))
-            DefaultOccupancyEvent(
+            DefaultOccupancyData(
                 connections = it.requireInt("connections"),
                 presenceMembers = it.requireInt("presenceMembers"),
             )

--- a/chat-android/src/main/java/com/ably/chat/Connection.kt
+++ b/chat-android/src/main/java/com/ably/chat/Connection.kt
@@ -139,9 +139,7 @@ internal class DefaultConnection(
     init {
         pubSubConnection.on { stateChange ->
             val nextStatus = mapPubSubStatusToChat(stateChange.current)
-            connectionScope.launch {
-                applyStatusChange(nextStatus, stateChange.reason, stateChange.retryIn)
-            }
+            applyStatusChange(nextStatus, stateChange.reason, stateChange.retryIn)
         }
     }
 
@@ -155,10 +153,10 @@ internal class DefaultConnection(
         }
     }
 
-    private fun applyStatusChange(nextStatus: ConnectionStatus, error: ErrorInfo?, retryIn: Long?) {
+    private fun applyStatusChange(nextStatus: ConnectionStatus, nextError: ErrorInfo?, retryIn: Long?) = connectionScope.launch {
         val previous = status
-        this.status = nextStatus
-        this.error = error
+        status = nextStatus
+        error = nextError
         logger.info("Connection state changed from ${previous.stateName} to ${nextStatus.stateName}")
         emitStateChange(
             DefaultConnectionStatusChange(

--- a/chat-android/src/main/java/com/ably/chat/Connection.kt
+++ b/chat-android/src/main/java/com/ably/chat/Connection.kt
@@ -3,21 +3,13 @@ package com.ably.chat
 import io.ably.lib.realtime.ConnectionState
 import io.ably.lib.types.ErrorInfo
 import java.util.concurrent.CopyOnWriteArrayList
-import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
 import io.ably.lib.realtime.Connection as PubSubConnection
-
-/**
- * Default timeout for transient states before we attempt handle them as a state change.
- */
-internal const val TRANSIENT_TIMEOUT = 5000
 
 /**
  * (CHA-CS1) The different states that the connection can be in through its lifecycle.
@@ -133,11 +125,9 @@ internal class DefaultConnection(
     dispatcher: CoroutineDispatcher = Dispatchers.Main,
 ) : Connection {
 
-    private val connectionScope = CoroutineScope(dispatcher.limitedParallelism(1) + SupervisorJob())
+    private val connectionScope = CoroutineScope(dispatcher + SupervisorJob())
 
     private val listeners: MutableList<Connection.Listener> = CopyOnWriteArrayList()
-
-    private var transientDisconnectJob: Job? = null
 
     // (CHA-CS3)
     override var status: ConnectionStatus = mapPubSubStatusToChat(pubSubConnection.state)
@@ -149,25 +139,7 @@ internal class DefaultConnection(
     init {
         pubSubConnection.on { stateChange ->
             val nextStatus = mapPubSubStatusToChat(stateChange.current)
-
-            val transientDisconnectTimerIsActive = transientDisconnectJob != null
-
-            // (CHA-CS5a2)
-            if (transientDisconnectTimerIsActive && nextStatus in listOf(ConnectionStatus.Connecting, ConnectionStatus.Disconnected)) {
-                return@on
-            }
-
-            // (CHA-CS5a1)
-            if (nextStatus == ConnectionStatus.Disconnected && status == ConnectionStatus.Connected) {
-                transientDisconnectJob = connectionScope.launch {
-                    delay(TRANSIENT_TIMEOUT.milliseconds)
-                    applyStatusChange(nextStatus, stateChange.reason, stateChange.retryIn)
-                    transientDisconnectJob = null
-                }
-            } else {
-                // (CHA-CS5a3)
-                transientDisconnectJob?.cancel()
-                transientDisconnectJob = null
+            connectionScope.launch {
                 applyStatusChange(nextStatus, stateChange.reason, stateChange.retryIn)
             }
         }

--- a/chat-android/src/main/java/com/ably/chat/EventTypes.kt
+++ b/chat-android/src/main/java/com/ably/chat/EventTypes.kt
@@ -1,11 +1,12 @@
 package com.ably.chat
 
 import io.ably.lib.types.MessageAction
+import io.ably.lib.types.PresenceMessage
 
 /**
  * All chat message events.
  */
-public enum class MessageEventType(public val eventName: String) {
+public enum class ChatMessageEventType(public val eventName: String) {
     /** Fires when a new chat message is received. */
     Created("message.created"),
 
@@ -40,9 +41,9 @@ internal val messageActionNameToAction = mapOf(
 )
 
 internal val messageActionToEventType = mapOf(
-    MessageAction.MESSAGE_CREATE to MessageEventType.Created,
-    MessageAction.MESSAGE_UPDATE to MessageEventType.Updated,
-    MessageAction.MESSAGE_DELETE to MessageEventType.Deleted,
+    MessageAction.MESSAGE_CREATE to ChatMessageEventType.Created,
+    MessageAction.MESSAGE_UPDATE to ChatMessageEventType.Updated,
+    MessageAction.MESSAGE_DELETE to ChatMessageEventType.Deleted,
 )
 
 /**
@@ -68,6 +69,19 @@ public enum class PresenceEventType(public val eventName: String) {
      * Event triggered when a user initially subscribes to presence.
      */
     Present("present"),
+    ;
+
+    internal companion object {
+        fun fromPresenceAction(action: PresenceMessage.Action): PresenceEventType {
+            return when (action) {
+                PresenceMessage.Action.absent -> throw clientError("event with type absent can't be received from the realtime")
+                PresenceMessage.Action.present -> Present
+                PresenceMessage.Action.enter -> Enter
+                PresenceMessage.Action.leave -> Leave
+                PresenceMessage.Action.update -> Update
+            }
+        }
+    }
 }
 
 /**

--- a/chat-android/src/main/java/com/ably/chat/Message.kt
+++ b/chat-android/src/main/java/com/ably/chat/Message.kt
@@ -137,11 +137,11 @@ public fun Message.copy(
     ) ?: throw clientError("Message interface is not suitable for inheritance")
 
 public fun Message.with(
-    event: MessageEvent,
+    event: ChatMessageEvent,
 ): Message {
     checkMessageSerial(event.message.serial)
 
-    if (event.type == MessageEventType.Created) { // CHA-M11a
+    if (event.type == ChatMessageEventType.Created) { // CHA-M11a
         throw clientError("MessageEvent.message.action must be MESSAGE_UPDATE or MESSAGE_DELETE")
     }
 

--- a/chat-android/src/main/java/com/ably/chat/Occupancy.kt
+++ b/chat-android/src/main/java/com/ably/chat/Occupancy.kt
@@ -89,8 +89,8 @@ public interface OccupancyEvent {
     public val occupancy: OccupancyData
 }
 
-public enum class OccupancyEventType {
-    Updated,
+public enum class OccupancyEventType(public val eventName: String) {
+    Updated("occupancy.updated"),
 }
 
 /**
@@ -185,7 +185,7 @@ internal class DefaultOccupancy(
     }
 
     override fun current(): OccupancyData? {
-        logger.trace("Occupancy.get()")
+        logger.trace("Occupancy.current()")
         if (!room.options.occupancy.enableEvents) { // CHA-O7c
             throw clientError("cannot get current occupancy; occupancy events are not enabled in room options")
         }

--- a/chat-android/src/main/java/com/ably/chat/Occupancy.kt
+++ b/chat-android/src/main/java/com/ably/chat/Occupancy.kt
@@ -39,9 +39,17 @@ public interface Occupancy {
     /**
      * Get the current occupancy of the chat room.
      *
-     * @returns the current occupancy of the chat room.
+     * @return the current occupancy of the chat room.
      */
-    public suspend fun get(): OccupancyEvent
+    public suspend fun get(): OccupancyData
+
+    /**
+     * Get the latest occupancy data received from realtime events.
+     *
+     * @return The latest occupancy data, or undefined if no realtime events have been received yet.
+     * @throws [io.ably.lib.types.AblyException] If occupancy events are not enabled for this room.
+     */
+    public fun current(): OccupancyData?
 
     /**
      * An interface for listening to new occupancy event
@@ -63,11 +71,34 @@ public fun Occupancy.asFlow(): Flow<OccupancyEvent> = transformCallbackAsFlow {
 }
 
 /**
- * Represents the occupancy of a chat room.
+ * Represents the occupancy event.
  *
  * (CHA-O2)
  */
 public interface OccupancyEvent {
+    /**
+     * Defines the type of the occupancy event, represented by an instance of [OccupancyEventType].
+     */
+    public val type: OccupancyEventType
+
+    /**
+     * Represents data about the occupancy of a chat room, including connection and presence details.
+     *
+     * Provides information such as the number of active connections and the number of presence members in the chat room.
+     */
+    public val occupancy: OccupancyData
+}
+
+public enum class OccupancyEventType {
+    Updated,
+}
+
+/**
+ * Represents the occupancy of a chat room.
+ *
+ * (CHA-O2)
+ */
+public interface OccupancyData {
     /**
      * The number of connections to the chat room.
      */
@@ -79,9 +110,14 @@ public interface OccupancyEvent {
     public val presenceMembers: Int
 }
 
-internal data class DefaultOccupancyEvent(
+internal data class DefaultOccupancyData(
     override val connections: Int,
     override val presenceMembers: Int,
+) : OccupancyData
+
+internal data class DefaultOccupancyEvent(
+    override val occupancy: DefaultOccupancyData,
+    override val type: OccupancyEventType = OccupancyEventType.Updated,
 ) : OccupancyEvent
 
 private const val META_OCCUPANCY_EVENT_NAME = "[meta]occupancy"
@@ -98,6 +134,8 @@ internal class DefaultOccupancy(
 
     @OptIn(InternalAPI::class)
     override val channel: Channel = channelWrapper.javaChannel
+
+    private var latestOccupancyData: OccupancyData? = null
 
     private val listeners: MutableList<Occupancy.Listener> = CopyOnWriteArrayList()
 
@@ -128,7 +166,7 @@ internal class DefaultOccupancy(
     // Spec: CHA-O4
     override fun subscribe(listener: Occupancy.Listener): Subscription {
         logger.trace("Occupancy.subscribe()")
-        if (room.options.occupancy?.enableEvents == false) { // CHA-O4e
+        if (!room.options.occupancy.enableEvents) { // CHA-O4e
             throw clientError("cannot subscribe to occupancy; occupancy events are not enabled in room options")
         }
 
@@ -141,9 +179,19 @@ internal class DefaultOccupancy(
     }
 
     // (CHA-O3)
-    override suspend fun get(): OccupancyEvent {
+    override suspend fun get(): OccupancyData {
         logger.trace("Occupancy.get()")
         return room.chatApi.getOccupancy(room.roomId)
+    }
+
+    override fun current(): OccupancyData? {
+        logger.trace("Occupancy.get()")
+        if (!room.options.occupancy.enableEvents) { // CHA-O7c
+            throw clientError("cannot get current occupancy; occupancy events are not enabled in room options")
+        }
+        // CHA-O7a
+        // CHA-O7b
+        return latestOccupancyData
     }
 
     override fun dispose() {
@@ -209,12 +257,16 @@ internal class DefaultOccupancy(
             return
         }
 
+        val occupancyData = DefaultOccupancyData(
+            connections = connections.asInt,
+            presenceMembers = presenceMembers.asInt,
+        )
+
+        latestOccupancyData = occupancyData
+
         eventBus.tryEmit(
             // (CHA-04c)
-            DefaultOccupancyEvent(
-                connections = connections.asInt,
-                presenceMembers = presenceMembers.asInt,
-            ),
+            DefaultOccupancyEvent(occupancyData),
         )
     }
 }

--- a/chat-android/src/main/java/com/ably/chat/RoomReactions.kt
+++ b/chat-android/src/main/java/com/ably/chat/RoomReactions.kt
@@ -55,14 +55,24 @@ public interface RoomReactions {
          * A function that can be called when the new reaction happens.
          * @param event The event that happened.
          */
-        public fun onReaction(event: Reaction)
+        public fun onReaction(event: RoomReactionEvent)
     }
 }
+
+public interface RoomReactionEvent {
+    public val type: RoomReactionEventType
+    public val reaction: Reaction
+}
+
+internal data class DefaultRoomReactionEvent(
+    override val reaction: Reaction,
+    override val type: RoomReactionEventType = RoomReactionEventType.Reaction,
+) : RoomReactionEvent
 
 /**
  * @return [Reaction] events as a [Flow]
  */
-public fun RoomReactions.asFlow(): Flow<Reaction> = transformCallbackAsFlow {
+public fun RoomReactions.asFlow(): Flow<RoomReactionEvent> = transformCallbackAsFlow {
     subscribe(it)
 }
 
@@ -161,7 +171,7 @@ internal class DefaultRoomReactions(
                 headers = pubSubMessage.extras?.asJsonObject()?.get("headers")?.toMap() ?: mapOf(),
                 isSelf = pubSubMessage.clientId == room.clientId,
             )
-            listener.onReaction(reaction)
+            listener.onReaction(DefaultRoomReactionEvent(reaction))
         }
         return channelWrapper.subscribe(RoomReactionEventType.Reaction.eventName, messageListener).asChatSubscription()
     }

--- a/chat-android/src/main/java/com/ably/chat/RoomReactions.kt
+++ b/chat-android/src/main/java/com/ably/chat/RoomReactions.kt
@@ -151,7 +151,7 @@ internal class DefaultRoomReactions(
                 )
             }
         }
-        room.ensureAttached(logger) // TODO - This check might be removed in the future due to core spec change
+        room.ensureConnected(logger) // CHA-ER3f
         channelWrapper.publishCoroutine(pubSubMessage.asEphemeralMessage()) // CHA-ER3d
     }
 

--- a/chat-android/src/main/java/com/ably/chat/Typing.kt
+++ b/chat-android/src/main/java/com/ably/chat/Typing.kt
@@ -3,7 +3,6 @@ package com.ably.chat
 import com.ably.annotations.InternalAPI
 import com.ably.pubsub.RealtimeChannel
 import io.ably.lib.realtime.Channel
-import io.ably.lib.realtime.ConnectionState
 import io.ably.lib.types.AblyException
 import io.ably.lib.types.ErrorInfo
 import io.ably.lib.types.Message
@@ -48,7 +47,7 @@ public interface Typing {
      * Current typing members.
      * @return set of clientIds that are currently typing.
      */
-    public fun get(): Set<String>
+    public fun current(): Set<String>
 
     /**
      * This will send a `typing.started` event to the server.
@@ -250,8 +249,8 @@ internal class DefaultTyping(
     /**
      * Spec: CHA-T9
      */
-    override fun get(): Set<String> {
-        logger.trace("DefaultTyping.get()")
+    override fun current(): Set<String> {
+        logger.trace("DefaultTyping.current()")
         return currentlyTypingMembers.toSet()
     }
 
@@ -259,17 +258,6 @@ internal class DefaultTyping(
      * Spec: CHA-T4, CHA-T14
      */
     override suspend fun keystroke() {
-        // CHA-T4e
-        if (room.realtimeClient.connection.state != ConnectionState.connected) {
-            logger.trace(
-                "DefaultTyping.keystroke(); connection is not connected",
-                context = mapOf(
-                    "status" to room.realtimeClient.connection.state.name,
-                ),
-            )
-            throw clientError("cannot type, connection is not connected")
-        }
-
         latestJobExecutor.run {
             // CHA-T4c - If heartbeat is active, it's a no-op
             typingHeartbeatStarted?.let {
@@ -278,8 +266,8 @@ internal class DefaultTyping(
                     return@run
                 }
             }
+            room.ensureConnected(logger) // CHA-T4a1, CHA-T4a3, CHA-T4a4, CHA-T4d, CHA-T4e
             // send typing.start event
-            room.ensureAttached(logger) // CHA-T4a1, CHA-T4a3, CHA-T4a4, CHA-T4d
             sendTyping(TypingEventType.Started) // CHA-T4a3
             typingHeartbeatStarted = timeSource.markNow() // CHA-T4a4
         }
@@ -303,7 +291,7 @@ internal class DefaultTyping(
                 }
             }
             // send typing.stop event
-            room.ensureAttached(logger) // CHA-T5e, CHA-T5c, CHA-T5d
+            room.ensureConnected(logger) // CHA-T5e, CHA-T5c, CHA-T5d
             sendTyping(TypingEventType.Stopped) // CHA-T5d
             typingHeartbeatStarted = null // CHA-T5e
         }
@@ -367,7 +355,7 @@ internal class DefaultTyping(
     private fun emit(eventType: TypingEventType, clientId: String) {
         val typingEventChange = DefaultTypingEventChange(eventType, clientId)
         listeners.forEach {
-            it.onEvent(DefaultTypingEvent(get(), typingEventChange))
+            it.onEvent(DefaultTypingEvent(current(), typingEventChange))
         }
     }
 }

--- a/chat-android/src/test/java/com/ably/chat/ConnectionTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/ConnectionTest.kt
@@ -11,10 +11,7 @@ import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.spyk
 import io.mockk.verify
-import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.test.StandardTestDispatcher
-import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -78,76 +75,6 @@ class ConnectionTest {
         )
     }
 
-    /**
-     * @spec: CHA-CS5a1
-     */
-    @Test
-    fun `should wait 5 sec if the connection status transitions from CONNECTED to DISCONNECTED`() = runTest {
-        val testScheduler = TestCoroutineScheduler()
-        val dispatcher = StandardTestDispatcher(testScheduler)
-        val connection = DefaultConnection(pubSubConnection, EmptyLogger(DefaultLogContext(tag = "TEST")), dispatcher)
-
-        var status = ConnectionStatus.Initialized
-
-        connection.onStatusChange {
-            status = it.current
-        }
-
-        fireConnected()
-
-        testScheduler.runCurrent()
-
-        assertEquals(ConnectionStatus.Connected, status)
-
-        fireDisconnected()
-
-        testScheduler.runCurrent()
-
-        assertEquals(ConnectionStatus.Connected, status)
-
-        testScheduler.advanceTimeBy(5000.milliseconds)
-        testScheduler.runCurrent()
-
-        assertEquals(ConnectionStatus.Disconnected, status)
-    }
-
-    /**
-     * @spec: CHA-CS5a3
-     */
-    @Test
-    fun `should cancel the transient disconnect timer IF realtime connections status changes to CONNECTED`() = runTest {
-        val testScheduler = TestCoroutineScheduler()
-        val dispatcher = StandardTestDispatcher(testScheduler)
-        val connection = DefaultConnection(pubSubConnection, EmptyLogger(DefaultLogContext(tag = "TEST")), dispatcher)
-
-        var status = ConnectionStatus.Initialized
-
-        connection.onStatusChange {
-            status = it.current
-        }
-
-        fireConnected()
-
-        testScheduler.runCurrent()
-
-        assertEquals(ConnectionStatus.Connected, status)
-
-        fireDisconnected()
-
-        testScheduler.runCurrent()
-
-        assertEquals(ConnectionStatus.Connected, status)
-
-        testScheduler.advanceTimeBy(3000.milliseconds)
-
-        fireConnected()
-
-        testScheduler.advanceTimeBy(5000.milliseconds)
-        testScheduler.runCurrent()
-
-        assertEquals(ConnectionStatus.Connected, status)
-    }
-
     @Test
     fun `statusAsFlow() should automatically unsubscribe then it's done`() = runTest {
         val connection: Connection = mockk()
@@ -170,22 +97,4 @@ class ConnectionTest {
             subscription.unsubscribe()
         }
     }
-
-    private fun fireConnected() = pubSubConnectionStateListenerSlot.captured.onConnectionStateChanged(
-        ConnectionStateChange(
-            ConnectionState.initialized,
-            ConnectionState.connected,
-            0,
-            null,
-        ),
-    )
-
-    private fun fireDisconnected() = pubSubConnectionStateListenerSlot.captured.onConnectionStateChanged(
-        ConnectionStateChange(
-            ConnectionState.connected,
-            ConnectionState.disconnected,
-            0,
-            null,
-        ),
-    )
 }

--- a/chat-android/src/test/java/com/ably/chat/ConnectionTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/ConnectionTest.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import io.ably.lib.realtime.Connection as PubSubConnection
 
@@ -23,6 +24,9 @@ class ConnectionTest {
     private val pubSubConnection = spyk<PubSubConnection>(buildRealtimeConnection())
 
     private val pubSubConnectionStateListenerSlot = slot<ConnectionStateListener>()
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
 
     @Before
     fun setUp() {

--- a/chat-android/src/test/java/com/ably/chat/MessageTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/MessageTest.kt
@@ -31,8 +31,8 @@ class MessageTest {
             version = "1",
             action = MessageAction.MESSAGE_UPDATE,
         )
-        val event = DefaultMessageEvent(
-            type = MessageEventType.Updated,
+        val event = DefaultChatMessageEvent(
+            type = ChatMessageEventType.Updated,
             message = eventMessage,
         )
 
@@ -56,8 +56,8 @@ class MessageTest {
             serial = "123",
             version = "2",
         )
-        val event = DefaultMessageEvent(
-            type = MessageEventType.Updated,
+        val event = DefaultChatMessageEvent(
+            type = ChatMessageEventType.Updated,
             message = eventMessage,
         )
 
@@ -82,8 +82,8 @@ class MessageTest {
             version = "1",
         )
 
-        val event = DefaultMessageEvent(
-            type = MessageEventType.Updated,
+        val event = DefaultChatMessageEvent(
+            type = ChatMessageEventType.Updated,
             message = eventMessage,
         )
 

--- a/chat-android/src/test/java/com/ably/chat/MessagesTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/MessagesTest.kt
@@ -92,7 +92,7 @@ class MessagesTest {
 
         every { messages.channelWrapper.subscribe("chat.message", capture(pubSubMessageListenerSlot)) } returns mockk()
 
-        val deferredValue = CompletableDeferred<MessageEvent>()
+        val deferredValue = CompletableDeferred<ChatMessageEvent>()
 
         messages.subscribe {
             deferredValue.complete(it)
@@ -127,7 +127,7 @@ class MessagesTest {
 
         val messageEvent = deferredValue.await()
 
-        assertEquals(MessageEventType.Created, messageEvent.type)
+        assertEquals(ChatMessageEventType.Created, messageEvent.type)
         assertEquals(
             DefaultMessage(
                 roomId = "room1",
@@ -155,7 +155,7 @@ class MessagesTest {
         subscription.unsubscribe()
 
         val exception = assertThrows(AblyException::class.java) {
-            runBlocking { subscription.getPreviousMessages() }
+            runBlocking { subscription.historyBeforeSubscribe() }
         }
 
         assertEquals(40_000, exception.errorInfo.code)
@@ -250,7 +250,7 @@ class MessagesTest {
         }
 
         messages.asFlow().test {
-            val event = mockk<MessageEvent>()
+            val event = mockk<ChatMessageEvent>()
             callback.onEvent(event)
             assertEquals(event, awaitItem())
             cancel()

--- a/chat-android/src/test/java/com/ably/chat/OccupancyTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/OccupancyTest.kt
@@ -53,7 +53,7 @@ class OccupancyTest {
             roomId = "room1",
         )
 
-        assertEquals(DefaultOccupancyEvent(connections = 2, presenceMembers = 1), occupancy.get())
+        assertEquals(DefaultOccupancyData(connections = 2, presenceMembers = 1), occupancy.get())
     }
 
     /**
@@ -81,7 +81,7 @@ class OccupancyTest {
 
         pubSubMessageListenerSlot.captured.onMessage(occupancyEventMessage)
 
-        assertEquals(DefaultOccupancyEvent(connections = 2, presenceMembers = 1), deferredEvent.await())
+        assertEquals(DefaultOccupancyData(connections = 2, presenceMembers = 1), deferredEvent.await().occupancy)
     }
 
     /**
@@ -115,7 +115,7 @@ class OccupancyTest {
         pubSubMessageListenerSlot.captured.onMessage(invalidOccupancyEvent)
         pubSubMessageListenerSlot.captured.onMessage(validOccupancyEvent)
 
-        assertEquals(DefaultOccupancyEvent(connections = 1, presenceMembers = 1), deferredEvent.await())
+        assertEquals(DefaultOccupancyData(connections = 1, presenceMembers = 1), deferredEvent.await().occupancy)
     }
 
     /**
@@ -149,7 +149,7 @@ class OccupancyTest {
 
         pubSubMessageListenerSlot.captured.onMessage(fakeMessage)
 
-        assertEquals(DefaultOccupancyEvent(connections = 1, presenceMembers = 1), deferredEvent.await())
+        assertEquals(DefaultOccupancyData(connections = 1, presenceMembers = 1), deferredEvent.await().occupancy)
     }
 
     @Test
@@ -189,7 +189,7 @@ class OccupancyTest {
         }
 
         occupancy.asFlow().test {
-            val event = DefaultOccupancyEvent(connections = 2, presenceMembers = 1)
+            val event = DefaultOccupancyEvent(DefaultOccupancyData(connections = 2, presenceMembers = 1))
             callback.onEvent(event)
             assertEquals(event, awaitItem())
             cancel()

--- a/chat-android/src/test/java/com/ably/chat/PresenceTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/PresenceTest.kt
@@ -64,10 +64,12 @@ class PresenceTest {
 
         assertEquals(
             DefaultPresenceEvent(
-                action = PresenceMessage.Action.leave,
-                clientId = "client1",
-                timestamp = 100_000L,
-                data = null,
+                type = PresenceEventType.Leave,
+                DefaultPresenceMember(
+                    clientId = "client1",
+                    updatedAt = 100_000L,
+                    data = null,
+                ),
             ),
             presenceEvent,
         )
@@ -101,10 +103,12 @@ class PresenceTest {
 
         assertEquals(
             DefaultPresenceEvent(
-                action = PresenceMessage.Action.leave,
-                clientId = "client1",
-                timestamp = 100_000L,
-                data = null,
+                type = PresenceEventType.Leave,
+                DefaultPresenceMember(
+                    clientId = "client1",
+                    updatedAt = 100_000L,
+                    data = null,
+                ),
             ),
             presenceEvent,
         )
@@ -140,10 +144,12 @@ class PresenceTest {
 
         assertEquals(
             DefaultPresenceEvent(
-                action = PresenceMessage.Action.leave,
-                clientId = "client1",
-                timestamp = 100_000L,
-                data = JsonPrimitive("user"),
+                type = PresenceEventType.Leave,
+                DefaultPresenceMember(
+                    clientId = "client1",
+                    updatedAt = 100_000L,
+                    data = JsonPrimitive("user"),
+                ),
             ),
             presenceEvent,
         )

--- a/chat-android/src/test/java/com/ably/chat/RoomReactionsTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/RoomReactionsTest.kt
@@ -7,6 +7,8 @@ import com.ably.chat.room.createTestRoom
 import com.ably.pubsub.RealtimeChannel
 import com.google.gson.JsonObject
 import io.ably.lib.realtime.CompletionListener
+import io.ably.lib.realtime.Connection
+import io.ably.lib.realtime.ConnectionState
 import io.ably.lib.types.Message
 import io.ably.lib.types.MessageExtras
 import io.mockk.coEvery
@@ -119,6 +121,12 @@ class RoomReactionsTest {
     @Test
     fun `(CHA-ER3d) Reactions are sent on the channel using an @ephemeral@ message`() = runTest {
         var publishedMessage: Message? = null
+        val connection = mockk<Connection>()
+        connection.state = ConnectionState.connected
+        val realtimeClient = room.realtimeClient
+
+        every { realtimeClient.connection } returns connection
+
         every {
             realtimeChannel.publish(any<Message>(), any<CompletionListener>())
         } answers {

--- a/chat-android/src/test/java/com/ably/chat/RoomReactionsTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/RoomReactionsTest.kt
@@ -49,7 +49,7 @@ class RoomReactionsTest {
 
         every { roomReactions.channelWrapper.subscribe("roomReaction", capture(pubSubMessageListenerSlot)) } returns mockk(relaxed = true)
 
-        val deferredValue = CompletableDeferred<Reaction>()
+        val deferredValue = CompletableDeferred<RoomReactionEvent>()
 
         roomReactions.subscribe {
             deferredValue.complete(it)
@@ -78,7 +78,7 @@ class RoomReactionsTest {
             },
         )
 
-        val reaction = deferredValue.await()
+        val reactionEvent = deferredValue.await()
 
         assertEquals(
             DefaultReaction(
@@ -89,7 +89,7 @@ class RoomReactionsTest {
                 headers = mapOf("foo" to "bar"),
                 isSelf = false,
             ),
-            reaction,
+            reactionEvent.reaction,
         )
     }
 
@@ -105,9 +105,9 @@ class RoomReactionsTest {
         }
 
         roomReactions.asFlow().test {
-            val reaction = mockk<Reaction>()
-            callback.onReaction(reaction)
-            assertEquals(reaction, awaitItem())
+            val reactionEvent = mockk<RoomReactionEvent>()
+            callback.onReaction(reactionEvent)
+            assertEquals(reactionEvent, awaitItem())
             cancel()
         }
 

--- a/chat-android/src/test/java/com/ably/chat/TestUtils.kt
+++ b/chat-android/src/test/java/com/ably/chat/TestUtils.kt
@@ -8,10 +8,16 @@ import io.mockk.every
 import io.mockk.mockk
 import java.lang.reflect.Field
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.setMain
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
 
 fun buildAsyncHttpPaginatedResponse(items: List<JsonElement>): AsyncHttpPaginatedResponse {
     val response = mockk<AsyncHttpPaginatedResponse>()
@@ -122,4 +128,13 @@ fun <T> Any.invokePrivateMethod(methodName: String, vararg args: Any?): T {
     method?.isAccessible = true
     @Suppress("UNCHECKED_CAST")
     return method?.invoke(this, *args) as T
+}
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MainDispatcherRule(
+    private val testDispatcher: TestDispatcher = UnconfinedTestDispatcher(),
+) : TestWatcher() {
+    override fun starting(description: Description) {
+        Dispatchers.setMain(testDispatcher)
+    }
 }

--- a/chat-android/src/test/java/com/ably/chat/TypingTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/TypingTest.kt
@@ -11,6 +11,8 @@ import com.ably.chat.room.createTestRoom
 import com.ably.chat.room.processEvent
 import com.ably.pubsub.RealtimeChannel
 import io.ably.lib.realtime.CompletionListener
+import io.ably.lib.realtime.Connection
+import io.ably.lib.realtime.ConnectionState
 import io.ably.lib.types.Message
 import io.mockk.coEvery
 import io.mockk.every
@@ -32,6 +34,7 @@ import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 
 class TypingTest {
@@ -41,9 +44,15 @@ class TypingTest {
     private var pubSubTypingListener: PubSubMessageListener? = null
     private lateinit var typingLogger: Logger
 
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
     @Before
     fun setUp() {
         val realtimeClient = createMockRealtimeClient()
+        val connection = mockk<Connection>()
+        connection.state = ConnectionState.connected
+        every { realtimeClient.connection } returns connection
 
         val channels = realtimeClient.channels
         every { channels.get(any(), any()) } returns realtimeChannel

--- a/chat-android/src/test/java/com/ably/chat/TypingTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/TypingTest.kt
@@ -227,7 +227,7 @@ class TypingTest {
             delay(500)
             typingEvents.size == 0
         }
-        assertTrue(typing.get().isEmpty())
+        assertTrue(typing.current().isEmpty())
 
         // Receive mock typing stop event with empty clientId
         receiveTypingEvent(TypingEventType.Stopped, "")
@@ -239,16 +239,16 @@ class TypingTest {
             delay(500)
             typingEvents.size == 0
         }
-        assertTrue(typing.get().isEmpty())
+        assertTrue(typing.current().isEmpty())
 
         // Receive mock typing event with valid clientId
         receiveTypingEvent(TypingEventType.Started, DEFAULT_CLIENT_ID)
         assertWaiter { typingEvents.size == 1 }
-        assertEquals(1, typing.get().size)
+        assertEquals(1, typing.current().size)
 
         receiveTypingEvent(TypingEventType.Stopped, DEFAULT_CLIENT_ID)
         assertWaiter { typingEvents.size == 2 }
-        assertEquals(0, typing.get().size)
+        assertEquals(0, typing.current().size)
 
         // No error detected
         verify(exactly = 2) {
@@ -317,7 +317,7 @@ class TypingTest {
         assertEquals(TypingEventType.Started, typingEvents[0].change.type)
         assertEquals(DEFAULT_CLIENT_ID, typingEvents[0].change.clientId)
 
-        assertEquals(setOf(DEFAULT_CLIENT_ID), typing.get()) // clientId added to internal set
+        assertEquals(setOf(DEFAULT_CLIENT_ID), typing.current()) // clientId added to internal set
         assertNotNull(typing.TypingStartEventPrunerJobs[DEFAULT_CLIENT_ID]) // self stop timer started
 
         testScheduler.advanceTimeBy(9.seconds)
@@ -336,7 +336,7 @@ class TypingTest {
         assertEquals(DEFAULT_CLIENT_ID, typingEvents[1].change.clientId)
 
         assertTrue(typing.TypingStartEventPrunerJobs.isEmpty())
-        assertTrue(typing.get().isEmpty())
+        assertTrue(typing.current().isEmpty())
     }
 
     /**
@@ -358,7 +358,7 @@ class TypingTest {
         assertEquals(TypingEventType.Started, typingEvents[0].change.type)
         assertEquals(DEFAULT_CLIENT_ID, typingEvents[0].change.clientId)
 
-        assertEquals(setOf(DEFAULT_CLIENT_ID), typing.get())
+        assertEquals(setOf(DEFAULT_CLIENT_ID), typing.current())
         assertNotNull(typing.TypingStartEventPrunerJobs[DEFAULT_CLIENT_ID])
 
         val activityTimer1 = typing.TypingStartEventPrunerJobs[DEFAULT_CLIENT_ID]
@@ -375,7 +375,7 @@ class TypingTest {
         assertEquals(DEFAULT_CLIENT_ID, typingEvents[1].change.clientId)
 
         assertTrue(typing.TypingStartEventPrunerJobs.isEmpty())
-        assertTrue(typing.get().isEmpty())
+        assertTrue(typing.current().isEmpty())
 
         // If stop event is received again, nothing is emitted
         receiveTypingEvent(TypingEventType.Stopped, DEFAULT_CLIENT_ID)
@@ -384,7 +384,7 @@ class TypingTest {
             typingEvents.size == 2
         }
         assertTrue(typing.TypingStartEventPrunerJobs.isEmpty())
-        assertTrue(typing.get().isEmpty())
+        assertTrue(typing.current().isEmpty())
     }
 
     /**
@@ -407,7 +407,7 @@ class TypingTest {
         assertEquals(TypingEventType.Started, typingEvents[0].change.type)
         assertEquals(DEFAULT_CLIENT_ID, typingEvents[0].change.clientId)
 
-        assertEquals(setOf(DEFAULT_CLIENT_ID), typing.get())
+        assertEquals(setOf(DEFAULT_CLIENT_ID), typing.current())
         assertNotNull(typing.TypingStartEventPrunerJobs[DEFAULT_CLIENT_ID])
 
         receiveTypingEvent(TypingEventType.Stopped, "missing-client-Id")
@@ -418,7 +418,7 @@ class TypingTest {
         }
 
         assertNotNull(typing.TypingStartEventPrunerJobs[DEFAULT_CLIENT_ID])
-        assertEquals(setOf(DEFAULT_CLIENT_ID), typing.get())
+        assertEquals(setOf(DEFAULT_CLIENT_ID), typing.current())
     }
 
     /**

--- a/chat-android/src/test/java/com/ably/chat/integration/ConnectionIntegrationTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/integration/ConnectionIntegrationTest.kt
@@ -3,13 +3,18 @@ package com.ably.chat.integration
 import com.ably.chat.ConnectionStatus
 import com.ably.chat.ConnectionStatusChange
 import com.ably.chat.DefaultConnectionStatusChange
+import com.ably.chat.MainDispatcherRule
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.BeforeClass
+import org.junit.Rule
 import org.junit.Test
 
 class ConnectionIntegrationTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
 
     @Test
     fun `should observe connection status`() = runTest {

--- a/chat-android/src/test/java/com/ably/chat/integration/MessageReactionsIntegrationTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/integration/MessageReactionsIntegrationTest.kt
@@ -1,8 +1,10 @@
 package com.ably.chat.integration
 
+import com.ably.chat.MainDispatcherRule
 import com.ably.chat.MessageReactionSummaryEvent
 import com.ably.chat.MessageReactionType
 import com.ably.chat.MessagesReactions
+import com.ably.chat.RetryTestRule
 import com.ably.chat.Room
 import com.ably.chat.Subscription
 import com.ably.chat.get
@@ -12,9 +14,16 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.BeforeClass
+import org.junit.Rule
 import org.junit.Test
 
 class MessageReactionsIntegrationTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    @get:Rule
+    val retryTestRule = RetryTestRule(3)
 
     /**
      * Spec: CHA-MR4, CHA-MR7

--- a/chat-android/src/test/java/com/ably/chat/integration/MessagesIntegrationTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/integration/MessagesIntegrationTest.kt
@@ -1,8 +1,9 @@
 package com.ably.chat.integration
 
 import com.ably.chat.BuildConfig
+import com.ably.chat.ChatMessageEvent
+import com.ably.chat.MainDispatcherRule
 import com.ably.chat.Message
-import com.ably.chat.MessageEvent
 import com.ably.chat.MessageMetadata
 import com.ably.chat.RoomStatus
 import com.ably.chat.assertWaiter
@@ -16,9 +17,13 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.BeforeClass
+import org.junit.Rule
 import org.junit.Test
 
 class MessagesIntegrationTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
 
     /**
      * Spec: CHA-M3, CHA-M4
@@ -32,7 +37,7 @@ class MessagesIntegrationTest {
 
         room.attach()
 
-        val messageEvent = CompletableDeferred<MessageEvent>()
+        val messageEvent = CompletableDeferred<ChatMessageEvent>()
 
         room.messages.subscribe { messageEvent.complete(it) }
         room.messages.send("hello")
@@ -55,7 +60,7 @@ class MessagesIntegrationTest {
 
         room.attach()
 
-        val messageEvent = CompletableDeferred<MessageEvent>()
+        val messageEvent = CompletableDeferred<ChatMessageEvent>()
         room.messages.subscribe { messageEvent.complete(it) }
 
         val metadata = MessageMetadata()
@@ -110,7 +115,7 @@ class MessagesIntegrationTest {
         lateinit var messages: List<Message>
 
         assertWaiter {
-            messages = room.messages.get().items
+            messages = room.messages.history().items
             messages.isNotEmpty()
         }
         assertEquals(1, messages.size)

--- a/chat-android/src/test/java/com/ably/chat/integration/OccupancyIntegrationTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/integration/OccupancyIntegrationTest.kt
@@ -1,6 +1,7 @@
 package com.ably.chat.integration
 
-import com.ably.chat.DefaultOccupancyEvent
+import com.ably.chat.DefaultOccupancyData
+import com.ably.chat.MainDispatcherRule
 import com.ably.chat.OccupancyEvent
 import com.ably.chat.get
 import com.ably.chat.occupancy
@@ -10,9 +11,13 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.BeforeClass
+import org.junit.Rule
 import org.junit.Test
 
 class OccupancyIntegrationTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
 
     @Test
     fun `should return occupancy for the client`() = runTest {
@@ -26,7 +31,7 @@ class OccupancyIntegrationTest {
         }
 
         chatClientRoom.attach()
-        assertEquals(DefaultOccupancyEvent(1, 0), firstOccupancyEvent.await())
+        assertEquals(DefaultOccupancyData(1, 0), firstOccupancyEvent.await().occupancy)
     }
 
     companion object {

--- a/chat-android/src/test/java/com/ably/chat/integration/PresenceIntegrationTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/integration/PresenceIntegrationTest.kt
@@ -1,12 +1,17 @@
 package com.ably.chat.integration
 
+import com.ably.chat.MainDispatcherRule
 import java.util.UUID
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.BeforeClass
+import org.junit.Rule
 import org.junit.Test
 
 class PresenceIntegrationTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
 
     @Test
     fun `should return empty list of presence members if nobody is entered`() = runTest {

--- a/chat-android/src/test/java/com/ably/chat/integration/ReactionsIntegrationTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/integration/ReactionsIntegrationTest.kt
@@ -1,6 +1,7 @@
 package com.ably.chat.integration
 
-import com.ably.chat.Reaction
+import com.ably.chat.MainDispatcherRule
+import com.ably.chat.RoomReactionEvent
 import com.ably.chat.get
 import com.ably.chat.reactions
 import java.util.UUID
@@ -8,9 +9,13 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.BeforeClass
+import org.junit.Rule
 import org.junit.Test
 
 class ReactionsIntegrationTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
 
     @Test
     fun `should observe room reactions`() = runTest {
@@ -20,7 +25,7 @@ class ReactionsIntegrationTest {
         val room = chatClient.rooms.get(roomId) { reactions() }
         room.attach()
 
-        val reactionEvent = CompletableDeferred<Reaction>()
+        val reactionEvent = CompletableDeferred<RoomReactionEvent>()
 
         room.reactions.subscribe { reactionEvent.complete(it) }
 
@@ -28,7 +33,7 @@ class ReactionsIntegrationTest {
 
         assertEquals(
             "heart",
-            reactionEvent.await().type,
+            reactionEvent.await().reaction.type,
         )
     }
 

--- a/chat-android/src/test/java/com/ably/chat/integration/RequestHeaderTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/integration/RequestHeaderTest.kt
@@ -22,7 +22,7 @@ class RequestHeaderTest {
         val roomId = UUID.randomUUID().toString()
 
         server.servedRequests.test {
-            chatClient.rooms.get(roomId).messages.get()
+            chatClient.rooms.get(roomId).messages.history()
             val agents = awaitItem().headers["ably-agent"]?.split(" ") ?: setOf()
             Assert.assertTrue(
                 agents.contains("chat-kotlin/${com.ably.chat.BuildConfig.APP_VERSION}"),

--- a/chat-android/src/test/java/com/ably/chat/integration/RoomIntegrationTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/integration/RoomIntegrationTest.kt
@@ -1,6 +1,7 @@
 package com.ably.chat.integration
 
 import com.ably.chat.ChatClient
+import com.ably.chat.MainDispatcherRule
 import com.ably.chat.Room
 import com.ably.chat.RoomStatus
 import com.ably.chat.RoomStatusChange
@@ -11,9 +12,13 @@ import java.util.UUID
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert
 import org.junit.BeforeClass
+import org.junit.Rule
 import org.junit.Test
 
 class RoomIntegrationTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
 
     private suspend fun validateAllOps(room: Room, chatClient: ChatClient) {
         Assert.assertEquals(RoomStatus.Initialized, room.status)

--- a/chat-android/src/test/java/com/ably/chat/integration/TypingIntegrationTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/integration/TypingIntegrationTest.kt
@@ -1,5 +1,6 @@
 package com.ably.chat.integration
 
+import com.ably.chat.MainDispatcherRule
 import com.ably.chat.TypingEventType
 import com.ably.chat.TypingSetEvent
 import com.ably.chat.TypingSetEventType
@@ -12,9 +13,13 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.BeforeClass
+import org.junit.Rule
 import org.junit.Test
 
 class TypingIntegrationTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
 
     /**
      * @spec CHA-T4, CHA-T9

--- a/chat-android/src/test/java/com/ably/chat/integration/TypingIntegrationTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/integration/TypingIntegrationTest.kt
@@ -35,8 +35,8 @@ class TypingIntegrationTest {
         val chatClient2Room = chatClient2.rooms.get(roomId) { typing { heartbeatThrottle = 10.seconds } }
         chatClient2Room.attach()
 
-        assertEquals(emptySet<String>(), chatClient1Room.typing.get())
-        assertEquals(emptySet<String>(), chatClient2Room.typing.get())
+        assertEquals(emptySet<String>(), chatClient1Room.typing.current())
+        assertEquals(emptySet<String>(), chatClient2Room.typing.current())
 
         val startTypingEventDeferred = CompletableDeferred<TypingSetEvent>()
         chatClient2Room.typing.subscribe {
@@ -50,8 +50,8 @@ class TypingIntegrationTest {
         assertEquals("client1", startTypingEvent.change.clientId)
         assertEquals(TypingEventType.Started, startTypingEvent.change.type)
 
-        assertEquals(setOf("client1"), chatClient1Room.typing.get())
-        assertEquals(setOf("client1"), chatClient2Room.typing.get())
+        assertEquals(setOf("client1"), chatClient1Room.typing.current())
+        assertEquals(setOf("client1"), chatClient2Room.typing.current())
     }
 
     /**
@@ -94,9 +94,9 @@ class TypingIntegrationTest {
         assertEquals("client2", startTypingEvent2.change.clientId)
         assertEquals(TypingEventType.Started, startTypingEvent2.change.type)
 
-        assertWaiter { chatClient1Room.typing.get() == setOf("client1", "client2") }
-        assertWaiter { chatClient2Room.typing.get() == setOf("client1", "client2") }
-        assertWaiter { chatClient3Room.typing.get() == setOf("client1", "client2") }
+        assertWaiter { chatClient1Room.typing.current() == setOf("client1", "client2") }
+        assertWaiter { chatClient2Room.typing.current() == setOf("client1", "client2") }
+        assertWaiter { chatClient3Room.typing.current() == setOf("client1", "client2") }
 
         // Client 1 stops typing
         val stopTypingEventDeferred1 = CompletableDeferred<TypingSetEvent>()
@@ -111,9 +111,9 @@ class TypingIntegrationTest {
         assertEquals("client1", stopTypingEvent1.change.clientId)
         assertEquals(TypingEventType.Stopped, stopTypingEvent1.change.type)
 
-        assertWaiter { chatClient1Room.typing.get() == setOf("client2") }
-        assertWaiter { chatClient2Room.typing.get() == setOf("client2") }
-        assertWaiter { chatClient3Room.typing.get() == setOf("client2") }
+        assertWaiter { chatClient1Room.typing.current() == setOf("client2") }
+        assertWaiter { chatClient2Room.typing.current() == setOf("client2") }
+        assertWaiter { chatClient3Room.typing.current() == setOf("client2") }
 
         // Client 2 stops typing
         val stopTypingEventDeferred2 = CompletableDeferred<TypingSetEvent>()
@@ -128,9 +128,9 @@ class TypingIntegrationTest {
         assertEquals("client2", stopTypingEvent2.change.clientId)
         assertEquals(TypingEventType.Stopped, stopTypingEvent2.change.type)
 
-        assertWaiter { chatClient1Room.typing.get().isEmpty() }
-        assertWaiter { chatClient2Room.typing.get().isEmpty() }
-        assertWaiter { chatClient3Room.typing.get().isEmpty() }
+        assertWaiter { chatClient1Room.typing.current().isEmpty() }
+        assertWaiter { chatClient2Room.typing.current().isEmpty() }
+        assertWaiter { chatClient3Room.typing.current().isEmpty() }
     }
 
     companion object {

--- a/chat-android/src/test/java/com/ably/chat/room/ConfigureRoomOptionsTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/room/ConfigureRoomOptionsTest.kt
@@ -3,6 +3,7 @@ package com.ably.chat.room
 import com.ably.chat.ChatApi
 import com.ably.chat.DefaultRoom
 import com.ably.chat.DefaultRooms
+import com.ably.chat.MainDispatcherRule
 import com.ably.chat.RoomStatus
 import com.ably.chat.Rooms
 import com.ably.chat.buildChatClientOptions
@@ -17,6 +18,7 @@ import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert
 import org.junit.Assert.assertThrows
+import org.junit.Rule
 import org.junit.Test
 
 /**
@@ -31,6 +33,9 @@ class ConfigureRoomOptionsTest {
     private val logger = createMockLogger()
     private val mockRealtimeClient = createMockRealtimeClient()
     private val chatApi = mockk<ChatApi>(relaxed = true)
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
 
     @Test
     fun `(CHA-RC2a) If a room is requested with a negative typing timeout, an ErrorInfo with code 40001 must be thrown`() = runTest {

--- a/chat-extensions-compose/src/main/kotlin/com/ably/chat/extensions/compose/Messages.kt
+++ b/chat-extensions-compose/src/main/kotlin/com/ably/chat/extensions/compose/Messages.kt
@@ -12,8 +12,8 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.SnapshotStateList
+import com.ably.chat.ChatMessageEventType
 import com.ably.chat.Message
-import com.ably.chat.MessageEventType
 import com.ably.chat.MessagesSubscription
 import com.ably.chat.PaginatedResult
 import com.ably.chat.Room
@@ -46,13 +46,13 @@ public fun Room.collectAsPagingMessagesState(scrollThreshold: Int = 10, fetchSiz
     DisposableEffect(this) {
         subscription = messages.subscribe { event ->
             when (event.type) {
-                MessageEventType.Created -> loaded.add(0, event.message)
+                ChatMessageEventType.Created -> loaded.add(0, event.message)
 
-                MessageEventType.Updated -> loaded.replaceFirstWith(event.message) {
+                ChatMessageEventType.Updated -> loaded.replaceFirstWith(event.message) {
                     it.serial == event.message.serial
                 }
 
-                MessageEventType.Deleted -> loaded.replaceFirstWith(event.message) {
+                ChatMessageEventType.Deleted -> loaded.replaceFirstWith(event.message) {
                     it.serial == event.message.serial
                 }
             }
@@ -91,7 +91,7 @@ public fun Room.collectAsPagingMessagesState(scrollThreshold: Int = 10, fetchSiz
 
         val receivedPaginatedResult = try {
             lastReceivedPaginatedResult?.next()
-                ?: subscription!!.getPreviousMessages(limit = fetchSize)
+                ?: subscription!!.historyBeforeSubscribe(limit = fetchSize)
         } catch (exception: AblyException) {
             error = exception.errorInfo
             return@LaunchedEffect

--- a/chat-extensions-compose/src/main/kotlin/com/ably/chat/extensions/compose/Occupancy.kt
+++ b/chat-extensions-compose/src/main/kotlin/com/ably/chat/extensions/compose/Occupancy.kt
@@ -48,8 +48,8 @@ public fun Room.collectAsOccupancy(): CurrentOccupancy {
         occupancy.asFlow().collect {
             if (initialOccupancyGet.isActive) initialOccupancyGet.cancelAndJoin()
             currentOccupancy = DefaultCurrentOccupancy(
-                connections = it.connections,
-                presenceMembers = it.presenceMembers,
+                connections = it.occupancy.connections,
+                presenceMembers = it.occupancy.presenceMembers,
             )
         }
     }

--- a/chat-extensions-compose/src/test/kotlin/com/ably/chat/extensions/compose/OccupancyTest.kt
+++ b/chat-extensions-compose/src/test/kotlin/com/ably/chat/extensions/compose/OccupancyTest.kt
@@ -4,7 +4,9 @@ import app.cash.molecule.RecompositionMode
 import app.cash.molecule.moleculeFlow
 import app.cash.turbine.test
 import com.ably.chat.Occupancy
+import com.ably.chat.OccupancyData
 import com.ably.chat.OccupancyEvent
+import com.ably.chat.OccupancyEventType
 import com.ably.chat.Room
 import com.ably.chat.RoomStatus
 import com.ably.chat.Subscription
@@ -69,8 +71,8 @@ class EmittingOccupancy(val mock: Occupancy) : Occupancy by mock {
         return Subscription { listeners.remove(listener) }
     }
 
-    override suspend fun get(): OccupancyEvent = mutex.withLock {
-        currentOccupancyEvent
+    override suspend fun get(): OccupancyData = mutex.withLock {
+        currentOccupancyEvent.occupancy
     }
 
     suspend fun pause() {
@@ -89,7 +91,11 @@ class EmittingOccupancy(val mock: Occupancy) : Occupancy by mock {
     }
 }
 
-fun OccupancyEvent(connections: Int, presenceMembers: Int): OccupancyEvent = mockk {
-    every { this@mockk.connections } returns connections
-    every { this@mockk.presenceMembers } returns presenceMembers
+fun OccupancyEvent(connections: Int, presenceMembers: Int): OccupancyEvent = mockk occupancyEvent@{
+    val occupancy = mockk<OccupancyData> occupancyData@{
+        every { this@occupancyData.connections } returns connections
+        every { this@occupancyData.presenceMembers } returns presenceMembers
+    }
+    every { this@occupancyEvent.type } returns OccupancyEventType.Updated
+    every { this@occupancyEvent.occupancy } returns occupancy
 }

--- a/chat-extensions-compose/src/test/kotlin/com/ably/chat/extensions/compose/PresenceTest.kt
+++ b/chat-extensions-compose/src/test/kotlin/com/ably/chat/extensions/compose/PresenceTest.kt
@@ -6,13 +6,13 @@ import app.cash.turbine.test
 import com.ably.chat.Presence
 import com.ably.chat.PresenceData
 import com.ably.chat.PresenceEvent
+import com.ably.chat.PresenceEventType
 import com.ably.chat.PresenceMember
 import com.ably.chat.Room
 import com.ably.chat.RoomStatus
 import com.ably.chat.Subscription
 import com.ably.chat.annotations.ExperimentalChatApi
 import com.google.gson.JsonObject
-import io.ably.lib.types.PresenceMessage
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.sync.Mutex
@@ -38,32 +38,30 @@ class PresenceTest {
             assertEquals(emptyList<PresenceMember>(), awaitItem())
             presence.emit(
                 PresenceEvent(
-                    action = PresenceMessage.Action.enter,
+                    type = PresenceEventType.Enter,
                     clientId = "client1",
                     data = null,
-                    timestamp = 0L,
+                    updatedAt = 0L,
                 ),
             )
             var members = awaitItem()
             assertEquals(1, members.size)
             assertEquals("client1", members.first().clientId)
-            assertEquals(PresenceMessage.Action.enter, members.first().action)
             assertNull(members.first().data)
             assertEquals(JsonObject(), members.first().extras)
             assertEquals(0, members.first().updatedAt)
 
             presence.emit(
                 PresenceEvent(
-                    action = PresenceMessage.Action.update,
+                    type = PresenceEventType.Enter,
                     clientId = "client1",
                     data = JsonObject(),
-                    timestamp = 1L,
+                    updatedAt = 1L,
                 ),
             )
             members = awaitItem()
             assertEquals(1, members.size)
             assertEquals("client1", members.first().clientId)
-            assertEquals(PresenceMessage.Action.update, members.first().action)
             assertEquals(JsonObject(), members.first().data)
             assertEquals(JsonObject(), members.first().extras)
             assertEquals(1, members.first().updatedAt)
@@ -74,10 +72,10 @@ class PresenceTest {
     fun `should cancel getting the initial presence set if event comes faster`() = runTest {
         presence.emit(
             PresenceEvent(
-                action = PresenceMessage.Action.enter,
+                type = PresenceEventType.Enter,
                 clientId = "client1",
                 data = null,
-                timestamp = 0L,
+                updatedAt = 0L,
             ),
         )
         presence.pause()
@@ -87,17 +85,16 @@ class PresenceTest {
             assertEquals(emptyList<PresenceMember>(), awaitItem())
             presence.emit(
                 PresenceEvent(
-                    action = PresenceMessage.Action.update,
+                    type = PresenceEventType.Update,
                     clientId = "client1",
                     data = JsonObject(),
-                    timestamp = 1L,
+                    updatedAt = 1L,
                 ),
             )
             presence.resume()
             val members = awaitItem()
             assertEquals(1, members.size)
             assertEquals("client1", members.first().clientId)
-            assertEquals(PresenceMessage.Action.update, members.first().action)
             assertEquals(JsonObject(), members.first().data)
             assertEquals(JsonObject(), members.first().extras)
             assertEquals(1, members.first().updatedAt)
@@ -130,36 +127,32 @@ class EmittingPresence(val mock: Presence) : Presence by mock {
     }
 
     fun emit(event: PresenceEvent) {
-        clientIdToPresenceMember[event.clientId] = PresenceMember(
-            clientId = event.clientId,
-            action = event.action,
-            data = event.data,
-            extras = JsonObject(),
-            updatedAt = event.timestamp,
-        )
+        clientIdToPresenceMember[event.member.clientId] = event.member
         listeners.forEach {
             it.onEvent(event)
         }
     }
 }
 
-fun PresenceEvent(action: PresenceMessage.Action, clientId: String, data: PresenceData?, timestamp: Long): PresenceEvent = mockk {
-    every { this@mockk.action } returns action
-    every { this@mockk.clientId } returns clientId
-    every { this@mockk.data } returns data
-    every { this@mockk.timestamp } returns timestamp
+fun PresenceEvent(
+    type: PresenceEventType,
+    clientId: String,
+    data: PresenceData?,
+    updatedAt: Long,
+    extras: JsonObject = JsonObject(),
+): PresenceEvent = mockk {
+    every { this@mockk.type } returns type
+    every { this@mockk.member } returns PresenceMember(clientId, data, updatedAt, extras)
 }
 
 fun PresenceMember(
     clientId: String,
     data: PresenceData?,
-    action: PresenceMessage.Action,
     updatedAt: Long,
     extras: JsonObject,
 ): PresenceMember = mockk {
     every { this@mockk.clientId } returns clientId
     every { this@mockk.data } returns data
-    every { this@mockk.action } returns action
     every { this@mockk.updatedAt } returns updatedAt
     every { this@mockk.extras } returns extras
 }

--- a/example/src/main/java/com/ably/chat/example/MainActivity.kt
+++ b/example/src/main/java/com/ably/chat/example/MainActivity.kt
@@ -154,7 +154,7 @@ fun Chat(room: Room, modifier: Modifier = Modifier) {
 
     LaunchedEffect(Unit) {
         room.reactions.asFlow().collect {
-            receivedReactions.add(it)
+            receivedReactions.add(it.reaction)
         }
     }
 


### PR DESCRIPTION
**BREAKING CHANGE:** Standardized naming for event and type-related classes, methods, and enums in the chat API, aligning with consistent naming conventions (e.g., `MessageEvent` to `ChatMessageEvent`). Updated related methods, tests, and documentation accordingly.

Additionally transient connection event handling has been removed

https://ably.atlassian.net/wiki/spaces/CHA/pages/3967713291/CHADR-101+Pre-GA+SDK+API+Review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added new abstractions for message, presence, occupancy, and reaction events, providing clearer event types and encapsulated event data.
  - Introduced methods to access the latest occupancy data and to retrieve message history with updated method names.
  - Added connection state verification before sending reactions and typing events to ensure active connection.

- **Bug Fixes**
  - Typing events now check for an active connection before sending, improving reliability.

- **Refactor**
  - Unified and renamed event types and interfaces for messages, presence, occupancy, and reactions for consistency and clarity.
  - Updated event listener interfaces and flow-based APIs to use new event abstractions.
  - Removed transient disconnect timeout logic for immediate connection state updates.

- **Tests**
  - Enhanced test reliability with new coroutine dispatcher and retry rules.
  - Updated tests to align with new event abstractions and naming conventions.
  - Removed obsolete tests related to transient connection timeouts.

- **Chores**
  - Improved test utilities for coroutine and retry management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->