### PR TITLE
[ECO-5343] refactor!: rename roomId to name or roomName

### DIFF
--- a/chat-android/src/main/java/com/ably/chat/Message.kt
+++ b/chat-android/src/main/java/com/ably/chat/Message.kt
@@ -33,11 +33,6 @@ public interface Message {
     public val clientId: String
 
     /**
-     * The roomId of the chat room to which the message belongs.
-     */
-    public val roomId: String
-
-    /**
      * The text of the message.
      */
     public val text: String
@@ -176,7 +171,6 @@ private fun Message.checkMessageSerial(serial: String) {
 internal data class DefaultMessage(
     override val serial: String,
     override val clientId: String,
-    override val roomId: String,
     override val text: String,
     override val createdAt: Long,
     override val metadata: MessageMetadata,
@@ -243,7 +237,6 @@ internal fun buildMessageReactions(jsonObject: JsonObject?): MessageReactions {
 internal object MessageProperty {
     const val Serial = "serial"
     const val ClientId = "clientId"
-    const val RoomId = "roomId"
     const val Text = "text"
     const val CreatedAt = "createdAt"
     const val Metadata = "metadata"

--- a/chat-android/src/main/java/com/ably/chat/MessagesReactions.kt
+++ b/chat-android/src/main/java/com/ably/chat/MessagesReactions.kt
@@ -271,7 +271,7 @@ internal data class DefaultMessageReaction(
 
 internal class DefaultMessagesReactions(
     private val chatApi: ChatApi,
-    private val roomId: String,
+    private val roomName: String,
     private val channel: Channel,
     private val annotations: RealtimeAnnotations,
     private val options: MessageOptions,
@@ -352,7 +352,7 @@ internal class DefaultMessagesReactions(
         )
 
         chatApi.sendMessageReaction(
-            roomId = roomId,
+            roomName = roomName,
             messageSerial = messageSerial,
             type = reactionType,
             name = name,
@@ -405,7 +405,7 @@ internal class DefaultMessagesReactions(
         }
 
         chatApi.deleteMessageReaction(
-            roomId = roomId,
+            roomName = roomName,
             messageSerial = messageSerial,
             type = reactionType,
             name = name,

--- a/chat-android/src/main/java/com/ably/chat/Occupancy.kt
+++ b/chat-android/src/main/java/com/ably/chat/Occupancy.kt
@@ -181,7 +181,7 @@ internal class DefaultOccupancy(
     // (CHA-O3)
     override suspend fun get(): OccupancyData {
         logger.trace("Occupancy.get()")
-        return room.chatApi.getOccupancy(room.roomId)
+        return room.chatApi.getOccupancy(room.name)
     }
 
     override fun current(): OccupancyData? {

--- a/chat-android/src/main/java/com/ably/chat/Utils.kt
+++ b/chat-android/src/main/java/com/ably/chat/Utils.kt
@@ -163,9 +163,9 @@ internal fun lifeCycleException(
     cause: Throwable? = null,
 ): AblyException = createAblyException(errorInfo, cause)
 
-internal fun roomInvalidStateException(roomId: String, roomStatus: RoomStatus, statusCode: Int) =
+internal fun roomInvalidStateException(roomName: String, roomStatus: RoomStatus, statusCode: Int) =
     ablyException(
-        "Can't perform operation; the room '$roomId' is in an invalid state: $roomStatus",
+        "Can't perform operation; the room '$roomName' is in an invalid state: $roomStatus",
         ErrorCode.RoomInInvalidState,
         statusCode,
     )

--- a/chat-android/src/test/java/com/ably/chat/AtomicCoroutineScopeTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/AtomicCoroutineScopeTest.kt
@@ -125,7 +125,7 @@ class AtomicCoroutineScopeTest {
 
     @Test
     fun `should perform mutually exclusive operations with custom room scope`() = runTest {
-        val roomScope = CoroutineScope(Dispatchers.Default.limitedParallelism(1) + CoroutineName("roomId"))
+        val roomScope = CoroutineScope(Dispatchers.Default.limitedParallelism(1) + CoroutineName("roomName"))
         val atomicCoroutineScope = AtomicCoroutineScope(roomScope)
         val deferredResults = mutableListOf<Deferred<Int>>()
 
@@ -156,7 +156,7 @@ class AtomicCoroutineScopeTest {
         val results = deferredResults.awaitAll()
         repeat(10) {
             Assert.assertEquals(it, results[it])
-            Assert.assertEquals("roomId", contextNames[it])
+            Assert.assertEquals("roomName", contextNames[it])
             assertThat(contexts[it], containsString("Dispatchers.Default.limitedParallelism(1)"))
         }
         assertWaiter { atomicCoroutineScope.finishedProcessing }

--- a/chat-android/src/test/java/com/ably/chat/ChatApiTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/ChatApiTest.kt
@@ -30,7 +30,6 @@ class ChatApiTest {
                     addProperty("foo", "bar")
                     add(MessageProperty.Metadata, JsonObject())
                     addProperty(MessageProperty.Serial, "timeserial")
-                    addProperty(MessageProperty.RoomId, "roomId")
                     addProperty(MessageProperty.ClientId, "clientId")
                     addProperty(MessageProperty.Text, "hello")
                     addProperty(MessageProperty.CreatedAt, 1_000_000)
@@ -41,13 +40,12 @@ class ChatApiTest {
             ),
         )
 
-        val messages = chatApi.getMessages("roomId", QueryOptions())
+        val messages = chatApi.getMessages("roomName", QueryOptions())
 
         assertEquals(
             listOf(
                 DefaultMessage(
                     serial = "timeserial",
-                    roomId = "roomId",
                     clientId = "clientId",
                     text = "hello",
                     createdAt = 1_000_000L,
@@ -78,7 +76,7 @@ class ChatApiTest {
         )
 
         val exception = assertThrows(AblyException::class.java) {
-            runBlocking { chatApi.getMessages("roomId", QueryOptions()) }
+            runBlocking { chatApi.getMessages("roomName", QueryOptions()) }
         }
 
         assertTrue(exception.message!!.matches(""".*Required field "\w+" is missing""".toRegex()))
@@ -98,12 +96,11 @@ class ChatApiTest {
             },
         )
 
-        val message = chatApi.sendMessage("roomId", SendMessageParams(text = "hello"))
+        val message = chatApi.sendMessage("roomName", SendMessageParams(text = "hello"))
 
         assertEquals(
             DefaultMessage(
                 serial = "timeserial",
-                roomId = "roomId",
                 clientId = "clientId",
                 text = "hello",
                 createdAt = 1_000_000L,
@@ -131,7 +128,7 @@ class ChatApiTest {
         )
 
         assertThrows(AblyException::class.java) {
-            runBlocking { chatApi.sendMessage("roomId", SendMessageParams(text = "hello")) }
+            runBlocking { chatApi.sendMessage("roomName", SendMessageParams(text = "hello")) }
         }
     }
 
@@ -148,7 +145,7 @@ class ChatApiTest {
         )
 
         assertThrows(AblyException::class.java) {
-            runBlocking { chatApi.getOccupancy("roomId") }
+            runBlocking { chatApi.getOccupancy("roomName") }
         }
     }
 }

--- a/chat-android/src/test/java/com/ably/chat/MessageTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/MessageTest.kt
@@ -186,7 +186,6 @@ private fun createMessage(
     serial = serial,
     version = version,
     clientId = "client1",
-    roomId = "room1",
     createdAt = System.currentTimeMillis(),
     metadata = JsonObject(),
     headers = mapOf(),

--- a/chat-android/src/test/java/com/ably/chat/MessagesReactionsTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/MessagesReactionsTest.kt
@@ -254,7 +254,7 @@ class MessagesReactionsTest {
 
     private fun createMessagesReaction(options: MessageOptions = MutableMessageOptions()) = DefaultMessagesReactions(
         chatApi = chatApi,
-        roomId = "room1",
+        roomName = "room1",
         channel = channel,
         annotations = annotations,
         options = options,

--- a/chat-android/src/test/java/com/ably/chat/MessagesTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/MessagesTest.kt
@@ -57,7 +57,7 @@ class MessagesTest {
                 addProperty(MessageProperty.Serial, "abcdefghij@1672531200000-123")
                 addProperty(MessageProperty.CreatedAt, 1_000_000)
             },
-            roomId = "room1",
+            roomName = "room1",
         )
 
         val sentMessage = messages.send(
@@ -70,7 +70,6 @@ class MessagesTest {
             DefaultMessage(
                 serial = "abcdefghij@1672531200000-123",
                 clientId = "clientId",
-                roomId = "room1",
                 text = "lala",
                 createdAt = 1_000_000,
                 metadata = JsonObject().apply { addProperty("meta", "data") },
@@ -130,7 +129,6 @@ class MessagesTest {
         assertEquals(ChatMessageEventType.Created, messageEvent.type)
         assertEquals(
             DefaultMessage(
-                roomId = "room1",
                 createdAt = 1000L,
                 clientId = "clientId",
                 serial = "abcdefghij@1672531200000-123",

--- a/chat-android/src/test/java/com/ably/chat/OccupancyTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/OccupancyTest.kt
@@ -50,7 +50,7 @@ class OccupancyTest {
                 addProperty("connections", 2)
                 addProperty("presenceMembers", 1)
             },
-            roomId = "room1",
+            roomName = "room1",
         )
 
         assertEquals(DefaultOccupancyData(connections = 2, presenceMembers = 1), occupancy.get())

--- a/chat-android/src/test/java/com/ably/chat/TestUtils.kt
+++ b/chat-android/src/test/java/com/ably/chat/TestUtils.kt
@@ -29,9 +29,9 @@ fun buildAsyncHttpPaginatedResponse(items: List<JsonElement>): AsyncHttpPaginate
     return response
 }
 
-fun mockMessagesApiResponse(realtimeClientMock: RealtimeClient, response: List<JsonElement>, roomId: String = "roomId") {
+fun mockMessagesApiResponse(realtimeClientMock: RealtimeClient, response: List<JsonElement>, roomName: String = "roomName") {
     every {
-        realtimeClientMock.requestAsync("/chat/v3/rooms/$roomId/messages", any(), HttpMethod.Get, any(), any(), any())
+        realtimeClientMock.requestAsync("/chat/v3/rooms/$roomName/messages", any(), HttpMethod.Get, any(), any(), any())
     } answers {
         val callback = secondArg<AsyncHttpPaginatedResponse.Callback>()
         callback.onResponse(
@@ -40,9 +40,9 @@ fun mockMessagesApiResponse(realtimeClientMock: RealtimeClient, response: List<J
     }
 }
 
-fun mockSendMessageApiResponse(realtimeClientMock: RealtimeClient, response: JsonElement, roomId: String = "roomId") {
+fun mockSendMessageApiResponse(realtimeClientMock: RealtimeClient, response: JsonElement, roomName: String = "roomName") {
     every {
-        realtimeClientMock.requestAsync("/chat/v3/rooms/$roomId/messages", any(), HttpMethod.Post, any(), any(), any())
+        realtimeClientMock.requestAsync("/chat/v3/rooms/$roomName/messages", any(), HttpMethod.Post, any(), any(), any())
     } answers {
         val callback = secondArg<AsyncHttpPaginatedResponse.Callback>()
         callback.onResponse(
@@ -53,9 +53,9 @@ fun mockSendMessageApiResponse(realtimeClientMock: RealtimeClient, response: Jso
     }
 }
 
-fun mockOccupancyApiResponse(realtimeClientMock: RealtimeClient, response: JsonElement, roomId: String = "roomId") {
+fun mockOccupancyApiResponse(realtimeClientMock: RealtimeClient, response: JsonElement, roomName: String = "roomName") {
     every {
-        realtimeClientMock.requestAsync("/chat/v3/rooms/$roomId/occupancy", any(), HttpMethod.Get, any(), any(), any())
+        realtimeClientMock.requestAsync("/chat/v3/rooms/$roomName/occupancy", any(), HttpMethod.Get, any(), any(), any())
     } answers {
         val callback = secondArg<AsyncHttpPaginatedResponse.Callback>()
         callback.onResponse(

--- a/chat-android/src/test/java/com/ably/chat/integration/MessageReactionsIntegrationTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/integration/MessageReactionsIntegrationTest.kt
@@ -31,8 +31,8 @@ class MessageReactionsIntegrationTest {
     @Test
     fun `should correctly send message reaction`() = runTest {
         val chatClient = sandbox.createSandboxChatClient()
-        val roomId = UUID.randomUUID().toString()
-        val room = chatClient.rooms.get(roomId) {
+        val roomName = UUID.randomUUID().toString()
+        val room = chatClient.rooms.get(roomName) {
             messages {
                 rawMessageReactions = true
             }
@@ -59,8 +59,8 @@ class MessageReactionsIntegrationTest {
     @Test
     fun `should correctly delete message reaction`() = runTest {
         val chatClient = sandbox.createSandboxChatClient()
-        val roomId = UUID.randomUUID().toString()
-        val room = chatClient.rooms.get(roomId)
+        val roomName = UUID.randomUUID().toString()
+        val room = chatClient.rooms.get(roomName)
         room.attach()
         val message = room.messages.send("test")
 
@@ -84,8 +84,8 @@ class MessageReactionsIntegrationTest {
     @Test
     fun `should delete with multiple summary type`() = runTest {
         val chatClient = sandbox.createSandboxChatClient()
-        val roomId = UUID.randomUUID().toString()
-        val room = chatClient.rooms.get(roomId)
+        val roomName = UUID.randomUUID().toString()
+        val room = chatClient.rooms.get(roomName)
         room.attach()
         val message = room.messages.send("test")
 
@@ -111,8 +111,8 @@ class MessageReactionsIntegrationTest {
     @Test
     fun `should use unique summary type`() = runTest {
         val chatClient = sandbox.createSandboxChatClient()
-        val roomId = UUID.randomUUID().toString()
-        val room = chatClient.rooms.get(roomId) {
+        val roomName = UUID.randomUUID().toString()
+        val room = chatClient.rooms.get(roomName) {
             messages {
                 defaultMessageReactionType = MessageReactionType.Unique
             }

--- a/chat-android/src/test/java/com/ably/chat/integration/MessagesIntegrationTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/integration/MessagesIntegrationTest.kt
@@ -31,9 +31,9 @@ class MessagesIntegrationTest {
     @Test
     fun `should be able to send and retrieve messages without room features`() = runTest {
         val chatClient = sandbox.createSandboxChatClient()
-        val roomId = UUID.randomUUID().toString()
+        val roomName = UUID.randomUUID().toString()
 
-        val room = chatClient.rooms.get(roomId)
+        val room = chatClient.rooms.get(roomName)
 
         room.attach()
 
@@ -54,9 +54,9 @@ class MessagesIntegrationTest {
     @Test
     fun `should be able to send and retrieve messages with all room features enabled`() = runTest {
         val chatClient = sandbox.createSandboxChatClient()
-        val roomId = UUID.randomUUID().toString()
+        val roomName = UUID.randomUUID().toString()
 
-        val room = chatClient.rooms.get(roomId, RoomOptionsWithAllFeatures)
+        val room = chatClient.rooms.get(roomName, RoomOptionsWithAllFeatures)
 
         room.attach()
 
@@ -70,7 +70,6 @@ class MessagesIntegrationTest {
 
         val receivedMessage = messageEvent.await().message
 
-        assertEquals(roomId, receivedMessage.roomId)
         assertEquals(MessageAction.MESSAGE_CREATE, receivedMessage.action)
         assertEquals("hello", receivedMessage.text)
         assertEquals("sandbox-client", receivedMessage.clientId)
@@ -84,7 +83,6 @@ class MessagesIntegrationTest {
         // check for sentMessage fields against receivedMessage fields
         assertEquals(sentMessage.serial, receivedMessage.serial)
         assertEquals(sentMessage.clientId, receivedMessage.clientId)
-        assertEquals(sentMessage.roomId, receivedMessage.roomId)
         assertEquals(sentMessage.text, receivedMessage.text)
         assertEquals(sentMessage.createdAt, receivedMessage.createdAt)
         assertEquals(sentMessage.metadata.toString(), receivedMessage.metadata.toString())
@@ -101,9 +99,9 @@ class MessagesIntegrationTest {
     @Test
     fun `should be able to send and retrieve messages from history`() = runTest {
         val chatClient = sandbox.createSandboxChatClient()
-        val roomId = UUID.randomUUID().toString()
+        val roomName = UUID.randomUUID().toString()
 
-        val room = chatClient.rooms.get(roomId)
+        val room = chatClient.rooms.get(roomName)
 
         room.attach()
 
@@ -121,7 +119,6 @@ class MessagesIntegrationTest {
         assertEquals(1, messages.size)
         val historyMessage = messages.first()
 
-        assertEquals(roomId, historyMessage.roomId)
         assertEquals(MessageAction.MESSAGE_CREATE, historyMessage.action)
         assertEquals("hello", historyMessage.text)
         assertEquals("sandbox-client", historyMessage.clientId)
@@ -135,7 +132,6 @@ class MessagesIntegrationTest {
         // check for sentMessage fields against historyMessage fields
         assertEquals(sentMessage.serial, historyMessage.serial)
         assertEquals(sentMessage.clientId, historyMessage.clientId)
-        assertEquals(sentMessage.roomId, historyMessage.roomId)
         assertEquals(sentMessage.text, historyMessage.text)
         assertEquals(sentMessage.createdAt, historyMessage.createdAt)
         assertEquals(sentMessage.metadata.toString(), historyMessage.metadata.toString())
@@ -152,9 +148,9 @@ class MessagesIntegrationTest {
     @Test
     fun `should be able to update a sent message`() = runTest {
         val chatClient = sandbox.createSandboxChatClient()
-        val roomId = UUID.randomUUID().toString()
+        val roomName = UUID.randomUUID().toString()
 
-        val room = chatClient.rooms.get(roomId)
+        val room = chatClient.rooms.get(roomName)
 
         room.attach()
         assertWaiter { room.status == RoomStatus.Attached }
@@ -200,7 +196,6 @@ class MessagesIntegrationTest {
         assertEquals(updatedMessage.createdAt, receivedMsg2.createdAt)
         assertEquals(updatedMessage.timestamp, receivedMsg2.timestamp)
         assertEquals(updatedMessage.clientId, receivedMsg2.clientId)
-        assertEquals(updatedMessage.roomId, receivedMsg2.roomId)
         assertEquals(updatedMessage.action, receivedMsg2.action)
     }
 
@@ -210,9 +205,9 @@ class MessagesIntegrationTest {
     @Test
     fun `should be able to delete a sent message`() = runTest {
         val chatClient = sandbox.createSandboxChatClient()
-        val roomId = UUID.randomUUID().toString()
+        val roomName = UUID.randomUUID().toString()
 
-        val room = chatClient.rooms.get(roomId)
+        val room = chatClient.rooms.get(roomName)
 
         room.attach()
         assertWaiter { room.status == RoomStatus.Attached }
@@ -252,15 +247,14 @@ class MessagesIntegrationTest {
         assertEquals(deletedMessage.createdAt, receivedMsg2.createdAt)
         assertEquals(deletedMessage.timestamp, receivedMsg2.timestamp)
         assertEquals(deletedMessage.clientId, receivedMsg2.clientId)
-        assertEquals(deletedMessage.roomId, receivedMsg2.roomId)
         assertEquals(deletedMessage.action, receivedMsg2.action)
     }
 
     @Test
     fun `messages channel should include agent channel param`() = runTest {
         val chatClient = sandbox.createSandboxChatClient()
-        val roomId = UUID.randomUUID().toString()
-        val room = chatClient.rooms.get(roomId)
+        val roomName = UUID.randomUUID().toString()
+        val room = chatClient.rooms.get(roomName)
         assertEquals(
             "chat-kotlin/${BuildConfig.APP_VERSION}",
             room.messages.channel.channelOptions?.params?.get("agent"),

--- a/chat-android/src/test/java/com/ably/chat/integration/OccupancyIntegrationTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/integration/OccupancyIntegrationTest.kt
@@ -22,8 +22,8 @@ class OccupancyIntegrationTest {
     @Test
     fun `should return occupancy for the client`() = runTest {
         val chatClient = sandbox.createSandboxChatClient("client1")
-        val roomId = UUID.randomUUID().toString()
-        val chatClientRoom = chatClient.rooms.get(roomId) { occupancy { enableEvents = true } }
+        val roomName = UUID.randomUUID().toString()
+        val chatClientRoom = chatClient.rooms.get(roomName) { occupancy { enableEvents = true } }
 
         val firstOccupancyEvent = CompletableDeferred<OccupancyEvent>()
         chatClientRoom.occupancy.subscribeOnce {

--- a/chat-android/src/test/java/com/ably/chat/integration/ReactionsIntegrationTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/integration/ReactionsIntegrationTest.kt
@@ -20,9 +20,9 @@ class ReactionsIntegrationTest {
     @Test
     fun `should observe room reactions`() = runTest {
         val chatClient = sandbox.createSandboxChatClient()
-        val roomId = UUID.randomUUID().toString()
+        val roomName = UUID.randomUUID().toString()
 
-        val room = chatClient.rooms.get(roomId) { reactions() }
+        val room = chatClient.rooms.get(roomName) { reactions() }
         room.attach()
 
         val reactionEvent = CompletableDeferred<RoomReactionEvent>()

--- a/chat-android/src/test/java/com/ably/chat/integration/RequestHeaderTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/integration/RequestHeaderTest.kt
@@ -19,10 +19,10 @@ class RequestHeaderTest {
     fun `should use additional agents in Realtime wrapper SDK client calls`() = runTest {
         val ablyRealtime = createAblyRealtime()
         val chatClient = ChatClient(ablyRealtime)
-        val roomId = UUID.randomUUID().toString()
+        val roomName = UUID.randomUUID().toString()
 
         server.servedRequests.test {
-            chatClient.rooms.get(roomId).messages.history()
+            chatClient.rooms.get(roomName).messages.history()
             val agents = awaitItem().headers["ably-agent"]?.split(" ") ?: setOf()
             Assert.assertTrue(
                 agents.contains("chat-kotlin/${com.ably.chat.BuildConfig.APP_VERSION}"),

--- a/chat-android/src/test/java/com/ably/chat/integration/RoomIntegrationTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/integration/RoomIntegrationTest.kt
@@ -38,7 +38,7 @@ class RoomIntegrationTest {
         Assert.assertEquals(RoomStatus.Detached, room.status)
 
         // Perform release operation
-        chatClient.rooms.release(room.roomId)
+        chatClient.rooms.release(room.name)
         Assert.assertEquals(RoomStatus.Released, room.status)
 
         assertWaiter { room.LifecycleManager.atomicCoroutineScope().finishedProcessing }
@@ -63,7 +63,7 @@ class RoomIntegrationTest {
         Assert.assertEquals(RoomStatus.Attached, room.status)
 
         // Perform release operation
-        chatClient.rooms.release(room.roomId)
+        chatClient.rooms.release(room.name)
         Assert.assertEquals(RoomStatus.Released, room.status)
 
         assertWaiter { room.LifecycleManager.atomicCoroutineScope().finishedProcessing }

--- a/chat-android/src/test/java/com/ably/chat/integration/TypingIntegrationTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/integration/TypingIntegrationTest.kt
@@ -28,11 +28,11 @@ class TypingIntegrationTest {
     fun `should return typing start indication for client`() = runTest {
         val chatClient1 = sandbox.createSandboxChatClient("client1")
         val chatClient2 = sandbox.createSandboxChatClient("client2")
-        val roomId = UUID.randomUUID().toString()
+        val roomName = UUID.randomUUID().toString()
 
-        val chatClient1Room = chatClient1.rooms.get(roomId) { typing { heartbeatThrottle = 10.seconds } }
+        val chatClient1Room = chatClient1.rooms.get(roomName) { typing { heartbeatThrottle = 10.seconds } }
         chatClient1Room.attach()
-        val chatClient2Room = chatClient2.rooms.get(roomId) { typing { heartbeatThrottle = 10.seconds } }
+        val chatClient2Room = chatClient2.rooms.get(roomName) { typing { heartbeatThrottle = 10.seconds } }
         chatClient2Room.attach()
 
         assertEquals(emptySet<String>(), chatClient1Room.typing.current())
@@ -63,12 +63,12 @@ class TypingIntegrationTest {
         val chatClient1 = sandbox.createSandboxChatClient("client1")
         val chatClient2 = sandbox.createSandboxChatClient("client2")
         val chatClient3 = sandbox.createSandboxChatClient("client3")
-        val roomId = UUID.randomUUID().toString()
-        val chatClient1Room = chatClient1.rooms.get(roomId) { typing { heartbeatThrottle = 10.seconds } }
+        val roomName = UUID.randomUUID().toString()
+        val chatClient1Room = chatClient1.rooms.get(roomName) { typing { heartbeatThrottle = 10.seconds } }
         chatClient1Room.attach()
-        val chatClient2Room = chatClient2.rooms.get(roomId) { typing { heartbeatThrottle = 10.seconds } }
+        val chatClient2Room = chatClient2.rooms.get(roomName) { typing { heartbeatThrottle = 10.seconds } }
         chatClient2Room.attach()
-        val chatClient3Room = chatClient3.rooms.get(roomId) { typing { heartbeatThrottle = 10.seconds } }
+        val chatClient3Room = chatClient3.rooms.get(roomName) { typing { heartbeatThrottle = 10.seconds } }
         chatClient3Room.attach()
 
         // Client 1, Client 2 starts typing

--- a/chat-android/src/test/java/com/ably/chat/room/RoomEnsureAttachedTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/room/RoomEnsureAttachedTest.kt
@@ -69,7 +69,7 @@ class RoomEnsureAttachedTest {
             val exception = result.exceptionOrNull() as AblyException
             Assert.assertEquals(ErrorCode.RoomInInvalidState.code, exception.errorInfo.code)
             Assert.assertEquals(HttpStatusCode.BadRequest, exception.errorInfo.statusCode)
-            val errMsg = "Can't perform operation; the room '${room.roomId}' is in an invalid state: $invalidStatus"
+            val errMsg = "Can't perform operation; the room '${room.name}' is in an invalid state: $invalidStatus"
             Assert.assertEquals(errMsg, exception.errorInfo.message)
         }
     }
@@ -162,7 +162,7 @@ class RoomEnsureAttachedTest {
             val exception = result.exceptionOrNull() as AblyException
             Assert.assertEquals(ErrorCode.RoomInInvalidState.code, exception.errorInfo.code)
             Assert.assertEquals(HttpStatusCode.InternalServerError, exception.errorInfo.statusCode)
-            val errMsg = "Can't perform operation; the room '${room.roomId}' is in an invalid state: $invalidStatus"
+            val errMsg = "Can't perform operation; the room '${room.name}' is in an invalid state: $invalidStatus"
             Assert.assertEquals(errMsg, exception.errorInfo.message)
 
             Assert.assertEquals(0, statusManager.InternalEmitter.Filters.size) // Emitted event processed

--- a/chat-android/src/test/java/com/ably/chat/room/RoomTestHelpers.kt
+++ b/chat-android/src/test/java/com/ably/chat/room/RoomTestHelpers.kt
@@ -88,14 +88,14 @@ internal fun createMockChatApi(
 internal fun createMockLogger(): Logger = mockk<AndroidLogger>(relaxed = true)
 
 internal fun createTestRoom(
-    roomId: String = DEFAULT_ROOM_ID,
+    roomName: String = DEFAULT_ROOM_ID,
     clientId: String = DEFAULT_CLIENT_ID,
     realtimeClient: RealtimeClient = createMockRealtimeClient(),
     chatApi: ChatApi = mockk<ChatApi>(relaxed = true),
     logger: Logger = createMockLogger(),
     roomOptions: (MutableRoomOptions.() -> Unit)? = null,
 ): DefaultRoom =
-    DefaultRoom(roomId, buildRoomOptions(roomOptions), realtimeClient, chatApi, clientId, logger)
+    DefaultRoom(roomName, buildRoomOptions(roomOptions), realtimeClient, chatApi, clientId, logger)
 
 internal val RoomOptionsWithAllFeatures: RoomOptions
     get() = buildRoomOptions {
@@ -108,7 +108,7 @@ internal val RoomOptionsWithAllFeatures: RoomOptions
     }
 
 // Rooms mocks
-val Rooms.RoomIdToRoom get() = getPrivateField<MutableMap<String, Room>>("roomIdToRoom")
+val Rooms.RoomNameToRoom get() = getPrivateField<MutableMap<String, Room>>("roomNameToRoom")
 val Rooms.RoomGetDeferredMap get() = getPrivateField<MutableMap<String, CompletableDeferred<Unit>>>("roomGetDeferredMap")
 val Rooms.RoomReleaseDeferredMap get() = getPrivateField<MutableMap<String, CompletableDeferred<Unit>>>("roomReleaseDeferredMap")
 
@@ -149,13 +149,13 @@ internal fun Typing.processEvent(eventType: TypingEventType, clientId: String) =
     invokePrivateMethod<Unit>("processReceivedTypingEvents", eventType, clientId)
 
 internal fun createRoomFeatureMocks(
-    roomId: String = DEFAULT_ROOM_ID,
+    roomName: String = DEFAULT_ROOM_ID,
     clientId: String = DEFAULT_CLIENT_ID,
 ): List<RoomFeature> {
     val realtimeClient = createMockRealtimeClient()
     val chatApi = createMockChatApi()
     val logger = createMockLogger()
-    val room = createTestRoom(roomId, clientId, realtimeClient, chatApi, logger)
+    val room = createTestRoom(roomName, clientId, realtimeClient, chatApi, logger)
 
     val messages = spyk(room.messages, recordPrivateCalls = true) as RoomFeature
     val presence = spyk(room.presence, recordPrivateCalls = true) as RoomFeature


### PR DESCRIPTION
**BREAKING CHANGE:** `roomId` has been renamed to `name` or `roomName` throughout the SDK. This is to align terminology more closely with other Ably SDKs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated all references from "roomId" to "roomName" throughout the chat library and test suite for improved consistency in naming.
  - Removed the "roomId" property from message objects; messages now no longer include this field.
  - Adjusted public interfaces and method signatures to use "roomName" instead of "roomId".

- **Tests**
  - Updated all test cases and helper functions to align with the new "roomName" naming convention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->