### PR TITLE
Release/0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Change Log
 
+## [0.4.0](https://github.com/ably/ably-chat-kotlin/tree/v0.4.0)
+
+[Full Changelog](https://github.com/ably/ably-chat-kotlin/compare/v0.3.0...v0.4.0)
+
+## What's Changed
+
+### New features
+
+The following features have been added in this release:
+
+- **Message reactions** Added __experimental__ support for message reactions. [#139](https://github.com/ably/ably-chat-kotlin/pull/139)
+
+### Breaking changes
+
+This release also includes several breaking changes:
+
+- `roomId` has been renamed to `name` or `roomName` throughout the SDK to align terminology with other Ably SDKs [#141](https://github.com/ably/ably-chat-kotlin/pull/141)
+- Event restructuring in Occupancy, Room Reactions, and Presence to match the style used by messages and typing indicators [#140](https://github.com/ably/ably-chat-kotlin/pull/140)
+- Sending typing indicators and room reactions now requires the connection status to be `Connected` [#140](https://github.com/ably/ably-chat-kotlin/pull/140)
+
+For detailed migration instructions, please refer to the [Upgrading Guide](UPGRADING.md).
+
 ## [0.3.0](https://github.com/ably/ably-chat-kotlin/tree/v0.3.0)
 
 [Full Changelog](https://github.com/ably/ably-chat-kotlin/compare/v0.2.1...v0.3.0)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <p style="text-align: left">
     <img src="https://badgen.net/github/license/3scale/saas-operator" alt="License" />
-    <img src="https://img.shields.io/badge/version-0.3.0-2ea44f" alt="version: 0.3.0" />
+    <img src="https://img.shields.io/badge/version-0.4.0-2ea44f" alt="version: 0.4.0" />
     <a href="https://github.com/ably/ably-chat-kotlin/actions/workflows/coverage.yml"><img src="https://img.shields.io/static/v1?label=coverage&message=80%2B%25&color=2ea44f" alt="coverage - 80+%"></a>
 </p>
 
@@ -39,13 +39,13 @@ The Ably Chat SDK is available on the Maven Central Repository. To include the d
 For Groovy:
 
 ```groovy
-implementation 'com.ably.chat:chat-android:0.3.0'
+implementation 'com.ably.chat:chat-android:0.4.0'
 ```
 
 For Kotlin Script (`build.gradle.kts`):
 
 ```kotlin
-implementation("com.ably.chat:chat-android:0.3.0")
+implementation("com.ably.chat:chat-android:0.4.0")
 ```
 
 ### Dependency on ably-android

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,98 @@
+# Upgrade Guide
+
+This guide provides detailed instructions on how to upgrade between versions of the Chat SDK.
+
+## 0.3.x to 0.4.x
+
+### Room ID Rename
+
+**Expected Impact: High**
+
+`roomId` has been renamed to `name` or `roomName` throughout the SDK.
+
+This is to align terminology more closely with other Ably SDKs.
+
+### Event Restructuring
+
+**Expected Impact: Medium**
+
+In Occupancy, Room Reactions and Presence, the event received by the listeners you subscribe has changed to match the style used by messages
+and typing indicators. The main change is that
+the entity (e.g. presence member) is now nested in the event.
+
+All of the data that you originally had accessible by the old event versions is still present, just in different places.
+
+#### Presence
+
+**Before**
+
+```kotlin
+room.presence.subscribe { event ->
+    // Log the presence member
+    println(event)
+
+    // Log the presence event type
+    println(event.action)
+}
+```
+
+**After**
+
+```kotlin
+room.presence.subscribe { event ->
+    // Log the presence member
+    println(event.member)
+
+    // Log the presence event type
+    println(event.type)
+}
+```
+
+#### Occupancy
+
+**Before**
+
+```kotlin
+room.occupancy.subscribe { event ->
+    // Log the number of connections
+    println(event.connections)
+}
+```
+
+**After**
+
+```kotlin
+room.occupancy.subscribe { event ->
+    // Log the number of connections
+    println(event.occupancy.connections)
+}
+```
+
+#### Room Reactions
+
+**Before**
+
+```kotlin
+room.reactions.subscribe { event ->
+    // Log the reaction type
+    println(event.type)
+}
+```
+
+**After**
+
+```kotlin
+room.reactions.subscribe { event ->
+    // Log the reaction type
+    println(event.reaction.type)
+}
+```
+
+### Operation Predicates
+
+**Expected Impact: Low**
+
+- Sending typing indicators now requires the connection status to be `Connected`.
+- Sending room reactions now requires the connection status to be `Connected`.
+
+This is to avoid messages being queued, which is in contrast to their ephemeral instantaneous use-case.

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@ android.useAndroidX=true
 
 # Maven Publish properties:
 GROUP=com.ably.chat
-VERSION_NAME=0.3.0
+VERSION_NAME=0.4.0
 
 POM_INCEPTION_YEAR=2024
 POM_URL=https://github.com/ably/ably-chat-kotlin


### PR DESCRIPTION
## What's Changed

### New features

The following features have been added in this release:

- **Message reactions** Added __experimental__ support for message reactions. [#139](https://github.com/ably/ably-chat-kotlin/pull/139)

### Breaking changes

This release also includes several breaking changes:

- `roomId` has been renamed to `name` or `roomName` throughout the SDK to align terminology with other Ably SDKs [#141](https://github.com/ably/ably-chat-kotlin/pull/141)
- Event restructuring in Occupancy, Room Reactions, and Presence to match the style used by messages and typing indicators [#140](https://github.com/ably/ably-chat-kotlin/pull/140)
- Sending typing indicators and room reactions now requires the connection status to be `Connected` [#140](https://github.com/ably/ably-chat-kotlin/pull/140)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Added a changelog entry for version 0.4.0, highlighting new features, breaking changes, and a link to an upgrade guide.
	- Introduced an upgrade guide to assist with migrating from version 0.3.x to 0.4.x, detailing key changes and their impact.
	- Updated the README to reflect the new version (0.4.0) in badges and installation instructions.

- **Chores**
	- Updated the project version to 0.4.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->