### PR TITLE
chore: update Maven Publish plugin and fix publishing configuration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,4 @@
 import com.vanniktech.maven.publish.MavenPublishBaseExtension
-import com.vanniktech.maven.publish.SonatypeHost
 
 plugins {
     alias(libs.plugins.detekt)
@@ -51,7 +50,6 @@ tasks.register("check") {
 configure(subprojects) {
     pluginManager.withPlugin("com.vanniktech.maven.publish") {
         extensions.configure<MavenPublishBaseExtension> {
-            publishToMavenCentral(SonatypeHost.S01)
             signAllPublications()
         }
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -34,3 +34,5 @@ POM_DEVELOPER_ID=ably
 POM_DEVELOPER_NAME=Ably
 POM_DEVELOPER_URL=https://github.com/ably/
 SONATYPE_STAGING_PROFILE=com.ably
+
+mavenCentralPublishing=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -74,5 +74,5 @@ android-application = { id = "com.android.application", version.ref = "agp" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 build-config = { id = "com.github.gmazzo.buildconfig", version.ref = "build-config" }
 kover = { id = "org.jetbrains.kotlinx.kover", version = "0.9.0-RC" }
-maven-publish = { id = "com.vanniktech.maven.publish", version = "0.30.0" }
+maven-publish = { id = "com.vanniktech.maven.publish", version = "0.34.0" }
 dokka = { id = "org.jetbrains.dokka", version = "1.9.20" }


### PR DESCRIPTION
From 30 June `S01` and `oss.sonatype.com` are migrated to the `central.sonatype.com`