### PR TITLE
docs: update version badge in `README.md` to use Maven Central link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![Ably Chat Header](images/AndroidSDK-github.png)
-[![Version](https://img.shields.io/badge/version-0.4.0-2ea44f)](https://github.com/ably/ably-chat-kotlin/releases/tag/v0.4.0)
+[![Version](https://img.shields.io/maven-central/v/com.ably.chat/chat-android?color=2ea44f&label=version)](https://central.sonatype.com/artifact/com.ably.chat/chat-android)
 [![License](https://badgen.net/github/license/ably/ably-chat-kotlin)](https://github.com/ably/ably-chat-kotlin/blob/main/LICENSE)
 
 


### PR DESCRIPTION
update version badge in `README.md` to use Maven Central link

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the SDK version badge in the README to display the latest version from Maven Central, ensuring users always see the most current release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->