### PR TITLE
[ECO-5478] feat: remove opinionated presence structure

### DIFF
--- a/chat-android/src/test/java/com/ably/chat/PresenceTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/PresenceTest.kt
@@ -55,6 +55,7 @@ class PresenceTest {
         presenceListenerSlot.captured.onPresenceMessage(
             PresenceMessage().apply {
                 action = PresenceMessage.Action.leave
+                connectionId = "foobar"
                 clientId = "client1"
                 timestamp = 100_000L
             },
@@ -67,6 +68,7 @@ class PresenceTest {
                 type = PresenceEventType.Leave,
                 DefaultPresenceMember(
                     clientId = "client1",
+                    connectionId = "foobar",
                     updatedAt = 100_000L,
                     data = null,
                 ),
@@ -79,7 +81,7 @@ class PresenceTest {
      * @spec CHA-PR2a
      */
     @Test
-    fun `should transform PresenceMessage into Chat's PresenceEvent if there is no 'userCustomData'`() = runTest {
+    fun `should transform PresenceMessage into Chat's PresenceEvent if there is empty data`() = runTest {
         val presenceListenerSlot = slot<PresenceListener>()
 
         every { pubSubPresence.subscribe(capture(presenceListenerSlot)) } returns mockk(relaxUnitFun = true)
@@ -94,6 +96,7 @@ class PresenceTest {
             PresenceMessage().apply {
                 action = PresenceMessage.Action.leave
                 clientId = "client1"
+                connectionId = "bar"
                 timestamp = 100_000L
                 data = JsonObject()
             },
@@ -106,8 +109,9 @@ class PresenceTest {
                 type = PresenceEventType.Leave,
                 DefaultPresenceMember(
                     clientId = "client1",
+                    connectionId = "bar",
                     updatedAt = 100_000L,
-                    data = null,
+                    data = JsonObject(),
                 ),
             ),
             presenceEvent,
@@ -118,7 +122,7 @@ class PresenceTest {
      * @spec CHA-PR2a
      */
     @Test
-    fun `should transform PresenceMessage into Chat's PresenceEvent if 'userCustomData' is primitive`() = runTest {
+    fun `should transform PresenceMessage into Chat's PresenceEvent if data is primitive`() = runTest {
         val presenceListenerSlot = slot<PresenceListener>()
 
         every { pubSubPresence.subscribe(capture(presenceListenerSlot)) } returns mockk(relaxUnitFun = true)
@@ -132,11 +136,10 @@ class PresenceTest {
         presenceListenerSlot.captured.onPresenceMessage(
             PresenceMessage().apply {
                 action = PresenceMessage.Action.leave
+                connectionId = "foo"
                 clientId = "client1"
                 timestamp = 100_000L
-                data = JsonObject().apply {
-                    addProperty("userCustomData", "user")
-                }
+                data = JsonPrimitive("user")
             },
         )
 
@@ -147,6 +150,7 @@ class PresenceTest {
                 type = PresenceEventType.Leave,
                 DefaultPresenceMember(
                     clientId = "client1",
+                    connectionId = "foo",
                     updatedAt = 100_000L,
                     data = JsonPrimitive("user"),
                 ),


### PR DESCRIPTION
Fixes https://github.com/ably/ably-chat-kotlin/issues/148

Removes the `userCustomData` key from presence and takes an unopinionated view on how presence should look.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Presence data is now handled directly, removing the extra "userCustomData" layer for a simpler and more consistent experience.
  * Presence members now explicitly include connection ID information.

* **Tests**
  * Updated test cases and method names to reflect the direct handling of presence data and inclusion of connection ID, ensuring accurate coverage for empty and primitive data scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->