### PR TITLE
feat: add binary-compatibility-validator plugin to ensure binary compatibility

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
     alias(libs.plugins.compose.compiler) apply false
     alias(libs.plugins.build.config) apply false
     alias(libs.plugins.maven.publish) apply false
+    alias(libs.plugins.binary.compatibility.validator) apply false
 }
 
 dependencies {

--- a/chat-android/api/chat-android.api
+++ b/chat-android/api/chat-android.api
@@ -1,0 +1,638 @@
+public abstract interface class com/ably/chat/ChatClient {
+	public abstract fun getClientId ()Ljava/lang/String;
+	public abstract fun getClientOptions ()Lcom/ably/chat/ChatClientOptions;
+	public abstract fun getConnection ()Lcom/ably/chat/Connection;
+	public abstract fun getRealtime ()Lio/ably/lib/realtime/AblyRealtime;
+	public abstract fun getRooms ()Lcom/ably/chat/Rooms;
+}
+
+public final class com/ably/chat/ChatClientKt {
+	public static final fun ChatClient (Lio/ably/lib/realtime/AblyRealtime;Lcom/ably/chat/ChatClientOptions;)Lcom/ably/chat/ChatClient;
+	public static final fun ChatClient (Lio/ably/lib/realtime/AblyRealtime;Lkotlin/jvm/functions/Function1;)Lcom/ably/chat/ChatClient;
+	public static synthetic fun ChatClient$default (Lio/ably/lib/realtime/AblyRealtime;Lcom/ably/chat/ChatClientOptions;ILjava/lang/Object;)Lcom/ably/chat/ChatClient;
+}
+
+public abstract interface class com/ably/chat/ChatClientOptions {
+	public abstract fun getLogHandler ()Lcom/ably/chat/LogHandler;
+	public abstract fun getLogLevel ()Lcom/ably/chat/LogLevel;
+}
+
+public final class com/ably/chat/ChatClientOptionsKt {
+	public static final fun buildChatClientOptions (Lkotlin/jvm/functions/Function1;)Lcom/ably/chat/ChatClientOptions;
+	public static synthetic fun buildChatClientOptions$default (Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/ably/chat/ChatClientOptions;
+}
+
+public abstract interface class com/ably/chat/ChatMessageEvent {
+	public abstract fun getMessage ()Lcom/ably/chat/Message;
+	public abstract fun getType ()Lcom/ably/chat/ChatMessageEventType;
+}
+
+public final class com/ably/chat/ChatMessageEventType : java/lang/Enum {
+	public static final field Created Lcom/ably/chat/ChatMessageEventType;
+	public static final field Deleted Lcom/ably/chat/ChatMessageEventType;
+	public static final field Updated Lcom/ably/chat/ChatMessageEventType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getEventName ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lcom/ably/chat/ChatMessageEventType;
+	public static fun values ()[Lcom/ably/chat/ChatMessageEventType;
+}
+
+public abstract interface class com/ably/chat/Connection {
+	public abstract fun getError ()Lio/ably/lib/types/ErrorInfo;
+	public abstract fun getStatus ()Lcom/ably/chat/ConnectionStatus;
+	public abstract fun onStatusChange (Lcom/ably/chat/Connection$Listener;)Lcom/ably/chat/Subscription;
+}
+
+public abstract interface class com/ably/chat/Connection$Listener {
+	public abstract fun connectionStatusChanged (Lcom/ably/chat/ConnectionStatusChange;)V
+}
+
+public final class com/ably/chat/ConnectionKt {
+	public static final fun statusAsFlow (Lcom/ably/chat/Connection;)Lkotlinx/coroutines/flow/Flow;
+}
+
+public final class com/ably/chat/ConnectionStatus : java/lang/Enum {
+	public static final field Connected Lcom/ably/chat/ConnectionStatus;
+	public static final field Connecting Lcom/ably/chat/ConnectionStatus;
+	public static final field Disconnected Lcom/ably/chat/ConnectionStatus;
+	public static final field Failed Lcom/ably/chat/ConnectionStatus;
+	public static final field Initialized Lcom/ably/chat/ConnectionStatus;
+	public static final field Suspended Lcom/ably/chat/ConnectionStatus;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getStateName ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lcom/ably/chat/ConnectionStatus;
+	public static fun values ()[Lcom/ably/chat/ConnectionStatus;
+}
+
+public abstract interface class com/ably/chat/ConnectionStatusChange {
+	public abstract fun getCurrent ()Lcom/ably/chat/ConnectionStatus;
+	public abstract fun getError ()Lio/ably/lib/types/ErrorInfo;
+	public abstract fun getPrevious ()Lcom/ably/chat/ConnectionStatus;
+	public abstract fun getRetryIn ()Ljava/lang/Long;
+}
+
+public abstract interface class com/ably/chat/Discontinuity {
+	public abstract fun onDiscontinuity (Lcom/ably/chat/Discontinuity$Listener;)Lcom/ably/chat/Subscription;
+}
+
+public abstract interface class com/ably/chat/Discontinuity$Listener {
+	public abstract fun discontinuityEmitted (Lio/ably/lib/types/ErrorInfo;)V
+}
+
+public final class com/ably/chat/DiscontinuityKt {
+	public static final fun discontinuityAsFlow (Lcom/ably/chat/Discontinuity;)Lkotlinx/coroutines/flow/Flow;
+}
+
+public final class com/ably/chat/ErrorCode : java/lang/Enum {
+	public static final field BadRequest Lcom/ably/chat/ErrorCode;
+	public static final field InternalError Lcom/ably/chat/ErrorCode;
+	public static final field InvalidRequestBody Lcom/ably/chat/ErrorCode;
+	public static final field MessageRejectedByBeforePublishRule Lcom/ably/chat/ErrorCode;
+	public static final field MessageRejectedByModeration Lcom/ably/chat/ErrorCode;
+	public static final field RoomDiscontinuity Lcom/ably/chat/ErrorCode;
+	public static final field RoomInFailedState Lcom/ably/chat/ErrorCode;
+	public static final field RoomInInvalidState Lcom/ably/chat/ErrorCode;
+	public static final field RoomIsReleased Lcom/ably/chat/ErrorCode;
+	public static final field RoomIsReleasing Lcom/ably/chat/ErrorCode;
+	public static final field RoomReleasedBeforeOperationCompleted Lcom/ably/chat/ErrorCode;
+	public final fun getCode ()I
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/ably/chat/ErrorCode;
+	public static fun values ()[Lcom/ably/chat/ErrorCode;
+}
+
+public final class com/ably/chat/HttpStatusCode {
+	public static final field BadRequest I
+	public static final field GatewayTimeout I
+	public static final field INSTANCE Lcom/ably/chat/HttpStatusCode;
+	public static final field InternalServerError I
+	public static final field NotImplemented I
+	public static final field ServiceUnavailable I
+	public static final field Timeout I
+	public static final field Unauthorized I
+}
+
+public abstract interface class com/ably/chat/LogContext {
+	public abstract fun getDynamicContext ()Ljava/util/Map;
+	public abstract fun getStaticContext ()Ljava/util/Map;
+	public abstract fun getTag ()Ljava/lang/String;
+}
+
+public abstract interface class com/ably/chat/LogHandler {
+	public abstract fun log (Ljava/lang/String;Lcom/ably/chat/LogLevel;Ljava/lang/Throwable;Lcom/ably/chat/LogContext;)V
+}
+
+public final class com/ably/chat/LogLevel : java/lang/Enum {
+	public static final field Debug Lcom/ably/chat/LogLevel;
+	public static final field Error Lcom/ably/chat/LogLevel;
+	public static final field Info Lcom/ably/chat/LogLevel;
+	public static final field Silent Lcom/ably/chat/LogLevel;
+	public static final field Trace Lcom/ably/chat/LogLevel;
+	public static final field Warn Lcom/ably/chat/LogLevel;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getLogLevelValue ()I
+	public static fun valueOf (Ljava/lang/String;)Lcom/ably/chat/LogLevel;
+	public static fun values ()[Lcom/ably/chat/LogLevel;
+}
+
+public abstract interface class com/ably/chat/Message {
+	public abstract fun getAction ()Lio/ably/lib/types/MessageAction;
+	public abstract fun getClientId ()Ljava/lang/String;
+	public abstract fun getCreatedAt ()J
+	public abstract fun getHeaders ()Ljava/util/Map;
+	public abstract fun getMetadata ()Lcom/google/gson/JsonObject;
+	public abstract fun getOperation ()Lio/ably/lib/types/Message$Operation;
+	public abstract fun getReactions ()Lcom/ably/chat/MessageReactions;
+	public abstract fun getSerial ()Ljava/lang/String;
+	public abstract fun getText ()Ljava/lang/String;
+	public abstract fun getTimestamp ()J
+	public abstract fun getVersion ()Ljava/lang/String;
+}
+
+public final class com/ably/chat/MessageKt {
+	public static final fun copy (Lcom/ably/chat/Message;Ljava/lang/String;Ljava/util/Map;Lcom/google/gson/JsonObject;)Lcom/ably/chat/Message;
+	public static synthetic fun copy$default (Lcom/ably/chat/Message;Ljava/lang/String;Ljava/util/Map;Lcom/google/gson/JsonObject;ILjava/lang/Object;)Lcom/ably/chat/Message;
+	public static final fun with (Lcom/ably/chat/Message;Lcom/ably/chat/ChatMessageEvent;)Lcom/ably/chat/Message;
+	public static final fun with (Lcom/ably/chat/Message;Lcom/ably/chat/MessageReactionSummaryEvent;)Lcom/ably/chat/Message;
+}
+
+public abstract interface class com/ably/chat/MessageOptions {
+	public abstract fun getDefaultMessageReactionType ()Lcom/ably/chat/MessageReactionType;
+	public abstract fun getRawMessageReactions ()Z
+}
+
+public abstract interface class com/ably/chat/MessageReaction {
+	public abstract fun getClientId ()Ljava/lang/String;
+	public abstract fun getCount ()Ljava/lang/Integer;
+	public abstract fun getMessageSerial ()Ljava/lang/String;
+	public abstract fun getName ()Ljava/lang/String;
+	public abstract fun getType ()Lcom/ably/chat/MessageReactionType;
+}
+
+public final class com/ably/chat/MessageReactionEventType : java/lang/Enum {
+	public static final field Create Lcom/ably/chat/MessageReactionEventType;
+	public static final field Delete Lcom/ably/chat/MessageReactionEventType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getEventName ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lcom/ably/chat/MessageReactionEventType;
+	public static fun values ()[Lcom/ably/chat/MessageReactionEventType;
+}
+
+public abstract interface class com/ably/chat/MessageReactionRawEvent {
+	public abstract fun getReaction ()Lcom/ably/chat/MessageReaction;
+	public abstract fun getTimestamp ()J
+	public abstract fun getType ()Lcom/ably/chat/MessageReactionEventType;
+}
+
+public abstract interface class com/ably/chat/MessageReactionSummaryEvent {
+	public abstract fun getSummary ()Lcom/ably/chat/MessageReactionsSummary;
+	public abstract fun getType ()Lcom/ably/chat/MessageReactionSummaryEventType;
+}
+
+public final class com/ably/chat/MessageReactionSummaryEventType : java/lang/Enum {
+	public static final field Summary Lcom/ably/chat/MessageReactionSummaryEventType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getEventName ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lcom/ably/chat/MessageReactionSummaryEventType;
+	public static fun values ()[Lcom/ably/chat/MessageReactionSummaryEventType;
+}
+
+public final class com/ably/chat/MessageReactionType : java/lang/Enum {
+	public static final field Distinct Lcom/ably/chat/MessageReactionType;
+	public static final field Multiple Lcom/ably/chat/MessageReactionType;
+	public static final field Unique Lcom/ably/chat/MessageReactionType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getType ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lcom/ably/chat/MessageReactionType;
+	public static fun values ()[Lcom/ably/chat/MessageReactionType;
+}
+
+public abstract interface class com/ably/chat/MessageReactions {
+	public abstract fun getDistinct ()Ljava/util/Map;
+	public abstract fun getMultiple ()Ljava/util/Map;
+	public abstract fun getUnique ()Ljava/util/Map;
+}
+
+public abstract interface class com/ably/chat/MessageReactionsSummary {
+	public abstract fun getDistinct ()Ljava/util/Map;
+	public abstract fun getMessageSerial ()Ljava/lang/String;
+	public abstract fun getMultiple ()Ljava/util/Map;
+	public abstract fun getUnique ()Ljava/util/Map;
+}
+
+public abstract interface class com/ably/chat/Messages {
+	public abstract fun delete (Lcom/ably/chat/Message;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getChannel ()Lio/ably/lib/realtime/Channel;
+	public abstract fun getReactions ()Lcom/ably/chat/MessagesReactions;
+	public abstract fun history (Ljava/lang/Long;Ljava/lang/Long;ILcom/ably/chat/OrderBy;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun send (Ljava/lang/String;Lcom/google/gson/JsonObject;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun subscribe (Lcom/ably/chat/Messages$Listener;)Lcom/ably/chat/MessagesSubscription;
+	public abstract fun update (Lcom/ably/chat/Message;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/ably/chat/Messages$DefaultImpls {
+	public static synthetic fun delete$default (Lcom/ably/chat/Messages;Lcom/ably/chat/Message;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun history$default (Lcom/ably/chat/Messages;Ljava/lang/Long;Ljava/lang/Long;ILcom/ably/chat/OrderBy;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun send$default (Lcom/ably/chat/Messages;Ljava/lang/String;Lcom/google/gson/JsonObject;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun update$default (Lcom/ably/chat/Messages;Lcom/ably/chat/Message;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public abstract interface class com/ably/chat/Messages$Listener {
+	public abstract fun onEvent (Lcom/ably/chat/ChatMessageEvent;)V
+}
+
+public final class com/ably/chat/MessagesKt {
+	public static final fun asFlow (Lcom/ably/chat/Messages;)Lkotlinx/coroutines/flow/Flow;
+}
+
+public abstract interface class com/ably/chat/MessagesReactions {
+	public abstract fun delete (Ljava/lang/String;Ljava/lang/String;Lcom/ably/chat/MessageReactionType;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun send (Ljava/lang/String;Ljava/lang/String;Lcom/ably/chat/MessageReactionType;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun subscribe (Lcom/ably/chat/MessagesReactions$Listener;)Lcom/ably/chat/Subscription;
+	public abstract fun subscribeRaw (Lcom/ably/chat/MessagesReactions$MessageRawReactionListener;)Lcom/ably/chat/Subscription;
+}
+
+public final class com/ably/chat/MessagesReactions$DefaultImpls {
+	public static synthetic fun delete$default (Lcom/ably/chat/MessagesReactions;Ljava/lang/String;Ljava/lang/String;Lcom/ably/chat/MessageReactionType;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun send$default (Lcom/ably/chat/MessagesReactions;Ljava/lang/String;Ljava/lang/String;Lcom/ably/chat/MessageReactionType;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public abstract interface class com/ably/chat/MessagesReactions$Listener {
+	public abstract fun onReactionSummary (Lcom/ably/chat/MessageReactionSummaryEvent;)V
+}
+
+public abstract interface class com/ably/chat/MessagesReactions$MessageRawReactionListener {
+	public abstract fun onRawReaction (Lcom/ably/chat/MessageReactionRawEvent;)V
+}
+
+public final class com/ably/chat/MessagesReactionsKt {
+	public static final fun delete (Lcom/ably/chat/MessagesReactions;Lcom/ably/chat/Message;Ljava/lang/String;Lcom/ably/chat/MessageReactionType;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun delete$default (Lcom/ably/chat/MessagesReactions;Lcom/ably/chat/Message;Ljava/lang/String;Lcom/ably/chat/MessageReactionType;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun send (Lcom/ably/chat/MessagesReactions;Lcom/ably/chat/Message;Ljava/lang/String;Lcom/ably/chat/MessageReactionType;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun send$default (Lcom/ably/chat/MessagesReactions;Lcom/ably/chat/Message;Ljava/lang/String;Lcom/ably/chat/MessageReactionType;ILkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public abstract interface class com/ably/chat/MessagesSubscription : com/ably/chat/Subscription {
+	public abstract fun historyBeforeSubscribe (Ljava/lang/Long;Ljava/lang/Long;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/ably/chat/MessagesSubscription$DefaultImpls {
+	public static synthetic fun historyBeforeSubscribe$default (Lcom/ably/chat/MessagesSubscription;Ljava/lang/Long;Ljava/lang/Long;ILkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class com/ably/chat/MutableChatClientOptions : com/ably/chat/ChatClientOptions {
+	public fun <init> ()V
+	public fun getLogHandler ()Lcom/ably/chat/LogHandler;
+	public fun getLogLevel ()Lcom/ably/chat/LogLevel;
+	public fun setLogHandler (Lcom/ably/chat/LogHandler;)V
+	public fun setLogLevel (Lcom/ably/chat/LogLevel;)V
+}
+
+public final class com/ably/chat/MutableMessageOptions : com/ably/chat/MessageOptions {
+	public fun <init> ()V
+	public fun getDefaultMessageReactionType ()Lcom/ably/chat/MessageReactionType;
+	public fun getRawMessageReactions ()Z
+	public fun setDefaultMessageReactionType (Lcom/ably/chat/MessageReactionType;)V
+	public fun setRawMessageReactions (Z)V
+}
+
+public final class com/ably/chat/MutableOccupancyOptions : com/ably/chat/OccupancyOptions {
+	public fun <init> ()V
+	public fun getEnableEvents ()Z
+	public fun setEnableEvents (Z)V
+}
+
+public final class com/ably/chat/MutablePresenceOptions : com/ably/chat/PresenceOptions {
+	public fun <init> ()V
+	public fun getEnableEvents ()Z
+	public fun setEnableEvents (Z)V
+}
+
+public final class com/ably/chat/MutableRoomOptions : com/ably/chat/RoomOptions {
+	public fun <init> ()V
+	public synthetic fun getMessages ()Lcom/ably/chat/MessageOptions;
+	public fun getMessages ()Lcom/ably/chat/MutableMessageOptions;
+	public fun getOccupancy ()Lcom/ably/chat/MutableOccupancyOptions;
+	public synthetic fun getOccupancy ()Lcom/ably/chat/OccupancyOptions;
+	public fun getPresence ()Lcom/ably/chat/MutablePresenceOptions;
+	public synthetic fun getPresence ()Lcom/ably/chat/PresenceOptions;
+	public fun getReactions ()Lcom/ably/chat/MutableRoomReactionsOptions;
+	public synthetic fun getReactions ()Lcom/ably/chat/RoomReactionsOptions;
+	public fun getTyping ()Lcom/ably/chat/MutableTypingOptions;
+	public synthetic fun getTyping ()Lcom/ably/chat/TypingOptions;
+	public fun setMessages (Lcom/ably/chat/MutableMessageOptions;)V
+	public fun setOccupancy (Lcom/ably/chat/MutableOccupancyOptions;)V
+	public fun setPresence (Lcom/ably/chat/MutablePresenceOptions;)V
+	public fun setReactions (Lcom/ably/chat/MutableRoomReactionsOptions;)V
+	public fun setTyping (Lcom/ably/chat/MutableTypingOptions;)V
+}
+
+public final class com/ably/chat/MutableRoomReactionsOptions : com/ably/chat/RoomReactionsOptions {
+	public fun <init> ()V
+}
+
+public final class com/ably/chat/MutableTypingOptions : com/ably/chat/TypingOptions {
+	public fun <init> ()V
+	public fun getHeartbeatThrottle-UwyO8pc ()J
+	public fun setHeartbeatThrottle-LRDsOJo (J)V
+}
+
+public abstract interface class com/ably/chat/Occupancy {
+	public abstract fun current ()Lcom/ably/chat/OccupancyData;
+	public abstract fun get (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getChannel ()Lio/ably/lib/realtime/Channel;
+	public abstract fun subscribe (Lcom/ably/chat/Occupancy$Listener;)Lcom/ably/chat/Subscription;
+}
+
+public abstract interface class com/ably/chat/Occupancy$Listener {
+	public abstract fun onEvent (Lcom/ably/chat/OccupancyEvent;)V
+}
+
+public abstract interface class com/ably/chat/OccupancyData {
+	public abstract fun getConnections ()I
+	public abstract fun getPresenceMembers ()I
+}
+
+public abstract interface class com/ably/chat/OccupancyEvent {
+	public abstract fun getOccupancy ()Lcom/ably/chat/OccupancyData;
+	public abstract fun getType ()Lcom/ably/chat/OccupancyEventType;
+}
+
+public final class com/ably/chat/OccupancyEventType : java/lang/Enum {
+	public static final field Updated Lcom/ably/chat/OccupancyEventType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getEventName ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lcom/ably/chat/OccupancyEventType;
+	public static fun values ()[Lcom/ably/chat/OccupancyEventType;
+}
+
+public final class com/ably/chat/OccupancyKt {
+	public static final fun asFlow (Lcom/ably/chat/Occupancy;)Lkotlinx/coroutines/flow/Flow;
+}
+
+public abstract interface class com/ably/chat/OccupancyOptions {
+	public abstract fun getEnableEvents ()Z
+}
+
+public final class com/ably/chat/OrderBy : java/lang/Enum {
+	public static final field NewestFirst Lcom/ably/chat/OrderBy;
+	public static final field OldestFirst Lcom/ably/chat/OrderBy;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/ably/chat/OrderBy;
+	public static fun values ()[Lcom/ably/chat/OrderBy;
+}
+
+public abstract interface class com/ably/chat/PaginatedResult {
+	public abstract fun getItems ()Ljava/util/List;
+	public abstract fun hasNext ()Z
+	public abstract fun next (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class com/ably/chat/Presence {
+	public abstract fun enter (Lcom/google/gson/JsonElement;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun get (ZLjava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getChannel ()Lio/ably/lib/realtime/Channel;
+	public abstract fun isUserPresent (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun leave (Lcom/google/gson/JsonElement;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun subscribe (Lcom/ably/chat/Presence$Listener;)Lcom/ably/chat/Subscription;
+	public abstract fun update (Lcom/google/gson/JsonElement;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/ably/chat/Presence$DefaultImpls {
+	public static synthetic fun enter$default (Lcom/ably/chat/Presence;Lcom/google/gson/JsonElement;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun get$default (Lcom/ably/chat/Presence;ZLjava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun leave$default (Lcom/ably/chat/Presence;Lcom/google/gson/JsonElement;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun update$default (Lcom/ably/chat/Presence;Lcom/google/gson/JsonElement;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public abstract interface class com/ably/chat/Presence$Listener {
+	public abstract fun onEvent (Lcom/ably/chat/PresenceEvent;)V
+}
+
+public abstract interface class com/ably/chat/PresenceEvent {
+	public abstract fun getMember ()Lcom/ably/chat/PresenceMember;
+	public abstract fun getType ()Lcom/ably/chat/PresenceEventType;
+}
+
+public final class com/ably/chat/PresenceEventType : java/lang/Enum {
+	public static final field Enter Lcom/ably/chat/PresenceEventType;
+	public static final field Leave Lcom/ably/chat/PresenceEventType;
+	public static final field Present Lcom/ably/chat/PresenceEventType;
+	public static final field Update Lcom/ably/chat/PresenceEventType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getEventName ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lcom/ably/chat/PresenceEventType;
+	public static fun values ()[Lcom/ably/chat/PresenceEventType;
+}
+
+public final class com/ably/chat/PresenceKt {
+	public static final fun asFlow (Lcom/ably/chat/Presence;)Lkotlinx/coroutines/flow/Flow;
+}
+
+public abstract interface class com/ably/chat/PresenceMember {
+	public abstract fun getClientId ()Ljava/lang/String;
+	public abstract fun getConnectionId ()Ljava/lang/String;
+	public abstract fun getData ()Lcom/google/gson/JsonElement;
+	public abstract fun getExtras ()Lcom/google/gson/JsonObject;
+	public abstract fun getUpdatedAt ()J
+}
+
+public abstract interface class com/ably/chat/PresenceOptions {
+	public abstract fun getEnableEvents ()Z
+}
+
+public final class com/ably/chat/PubSubEventName {
+	public static final field ChatMessage Ljava/lang/String;
+	public static final field INSTANCE Lcom/ably/chat/PubSubEventName;
+}
+
+public abstract interface class com/ably/chat/Room : com/ably/chat/Discontinuity {
+	public abstract fun attach (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun detach (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getChannel ()Lcom/ably/pubsub/RealtimeChannel;
+	public abstract fun getError ()Lio/ably/lib/types/ErrorInfo;
+	public abstract fun getMessages ()Lcom/ably/chat/Messages;
+	public abstract fun getName ()Ljava/lang/String;
+	public abstract fun getOccupancy ()Lcom/ably/chat/Occupancy;
+	public abstract fun getOptions ()Lcom/ably/chat/RoomOptions;
+	public abstract fun getPresence ()Lcom/ably/chat/Presence;
+	public abstract fun getReactions ()Lcom/ably/chat/RoomReactions;
+	public abstract fun getStatus ()Lcom/ably/chat/RoomStatus;
+	public abstract fun getTyping ()Lcom/ably/chat/Typing;
+	public abstract fun onStatusChange (Lcom/ably/chat/Room$Listener;)Lcom/ably/chat/Subscription;
+}
+
+public abstract interface class com/ably/chat/Room$Listener {
+	public abstract fun roomStatusChanged (Lcom/ably/chat/RoomStatusChange;)V
+}
+
+public final class com/ably/chat/RoomEvent : java/lang/Enum {
+	public static final field Discontinuity Lcom/ably/chat/RoomEvent;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getEvent ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lcom/ably/chat/RoomEvent;
+	public static fun values ()[Lcom/ably/chat/RoomEvent;
+}
+
+public final class com/ably/chat/RoomKt {
+	public static final fun statusAsFlow (Lcom/ably/chat/Room;)Lkotlinx/coroutines/flow/Flow;
+}
+
+public abstract interface class com/ably/chat/RoomOptions {
+	public abstract fun getMessages ()Lcom/ably/chat/MessageOptions;
+	public abstract fun getOccupancy ()Lcom/ably/chat/OccupancyOptions;
+	public abstract fun getPresence ()Lcom/ably/chat/PresenceOptions;
+	public abstract fun getReactions ()Lcom/ably/chat/RoomReactionsOptions;
+	public abstract fun getTyping ()Lcom/ably/chat/TypingOptions;
+}
+
+public final class com/ably/chat/RoomOptionsKt {
+	public static final fun messages (Lcom/ably/chat/MutableRoomOptions;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun messages$default (Lcom/ably/chat/MutableRoomOptions;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun occupancy (Lcom/ably/chat/MutableRoomOptions;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun occupancy$default (Lcom/ably/chat/MutableRoomOptions;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun presence (Lcom/ably/chat/MutableRoomOptions;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun presence$default (Lcom/ably/chat/MutableRoomOptions;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun reactions (Lcom/ably/chat/MutableRoomOptions;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun reactions$default (Lcom/ably/chat/MutableRoomOptions;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun typing (Lcom/ably/chat/MutableRoomOptions;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun typing$default (Lcom/ably/chat/MutableRoomOptions;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+}
+
+public abstract interface class com/ably/chat/RoomReaction {
+	public abstract fun getClientId ()Ljava/lang/String;
+	public abstract fun getCreatedAt ()J
+	public abstract fun getHeaders ()Ljava/util/Map;
+	public abstract fun getMetadata ()Lcom/google/gson/JsonObject;
+	public abstract fun getName ()Ljava/lang/String;
+	public abstract fun isSelf ()Z
+}
+
+public abstract interface class com/ably/chat/RoomReactionEvent {
+	public abstract fun getReaction ()Lcom/ably/chat/RoomReaction;
+	public abstract fun getType ()Lcom/ably/chat/RoomReactionEventType;
+}
+
+public final class com/ably/chat/RoomReactionEventType : java/lang/Enum {
+	public static final field Reaction Lcom/ably/chat/RoomReactionEventType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getEventName ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lcom/ably/chat/RoomReactionEventType;
+	public static fun values ()[Lcom/ably/chat/RoomReactionEventType;
+}
+
+public abstract interface class com/ably/chat/RoomReactions {
+	public abstract fun getChannel ()Lio/ably/lib/realtime/Channel;
+	public abstract fun send (Ljava/lang/String;Lcom/google/gson/JsonObject;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun subscribe (Lcom/ably/chat/RoomReactions$Listener;)Lcom/ably/chat/Subscription;
+}
+
+public final class com/ably/chat/RoomReactions$DefaultImpls {
+	public static synthetic fun send$default (Lcom/ably/chat/RoomReactions;Ljava/lang/String;Lcom/google/gson/JsonObject;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public abstract interface class com/ably/chat/RoomReactions$Listener {
+	public abstract fun onReaction (Lcom/ably/chat/RoomReactionEvent;)V
+}
+
+public final class com/ably/chat/RoomReactionsKt {
+	public static final fun asFlow (Lcom/ably/chat/RoomReactions;)Lkotlinx/coroutines/flow/Flow;
+}
+
+public abstract interface class com/ably/chat/RoomReactionsOptions {
+}
+
+public final class com/ably/chat/RoomStatus : java/lang/Enum {
+	public static final field Attached Lcom/ably/chat/RoomStatus;
+	public static final field Attaching Lcom/ably/chat/RoomStatus;
+	public static final field Detached Lcom/ably/chat/RoomStatus;
+	public static final field Detaching Lcom/ably/chat/RoomStatus;
+	public static final field Failed Lcom/ably/chat/RoomStatus;
+	public static final field Initialized Lcom/ably/chat/RoomStatus;
+	public static final field Released Lcom/ably/chat/RoomStatus;
+	public static final field Releasing Lcom/ably/chat/RoomStatus;
+	public static final field Suspended Lcom/ably/chat/RoomStatus;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getStateName ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lcom/ably/chat/RoomStatus;
+	public static fun values ()[Lcom/ably/chat/RoomStatus;
+}
+
+public abstract interface class com/ably/chat/RoomStatusChange {
+	public abstract fun getCurrent ()Lcom/ably/chat/RoomStatus;
+	public abstract fun getError ()Lio/ably/lib/types/ErrorInfo;
+	public abstract fun getPrevious ()Lcom/ably/chat/RoomStatus;
+}
+
+public abstract interface class com/ably/chat/Rooms {
+	public abstract fun get (Ljava/lang/String;Lcom/ably/chat/RoomOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getClientOptions ()Lcom/ably/chat/ChatClientOptions;
+	public abstract fun release (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/ably/chat/Rooms$DefaultImpls {
+	public static synthetic fun get$default (Lcom/ably/chat/Rooms;Ljava/lang/String;Lcom/ably/chat/RoomOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class com/ably/chat/RoomsKt {
+	public static final fun get (Lcom/ably/chat/Rooms;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class com/ably/chat/Subscription {
+	public abstract fun unsubscribe ()V
+}
+
+public abstract interface class com/ably/chat/Typing {
+	public abstract fun current ()Ljava/util/Set;
+	public abstract fun getChannel ()Lio/ably/lib/realtime/Channel;
+	public abstract fun keystroke (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun stop (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun subscribe (Lcom/ably/chat/Typing$Listener;)Lcom/ably/chat/Subscription;
+}
+
+public abstract interface class com/ably/chat/Typing$Listener {
+	public abstract fun onEvent (Lcom/ably/chat/TypingSetEvent;)V
+}
+
+public final class com/ably/chat/TypingEventType : java/lang/Enum {
+	public static final field Started Lcom/ably/chat/TypingEventType;
+	public static final field Stopped Lcom/ably/chat/TypingEventType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getEventName ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lcom/ably/chat/TypingEventType;
+	public static fun values ()[Lcom/ably/chat/TypingEventType;
+}
+
+public final class com/ably/chat/TypingKt {
+	public static final fun asFlow (Lcom/ably/chat/Typing;)Lkotlinx/coroutines/flow/Flow;
+}
+
+public abstract interface class com/ably/chat/TypingOptions {
+	public abstract fun getHeartbeatThrottle-UwyO8pc ()J
+}
+
+public abstract interface class com/ably/chat/TypingSetEvent {
+	public abstract fun getChange ()Lcom/ably/chat/TypingSetEvent$Change;
+	public abstract fun getCurrentlyTyping ()Ljava/util/Set;
+	public abstract fun getType ()Lcom/ably/chat/TypingSetEventType;
+}
+
+public abstract interface class com/ably/chat/TypingSetEvent$Change {
+	public abstract fun getClientId ()Ljava/lang/String;
+	public abstract fun getType ()Lcom/ably/chat/TypingEventType;
+}
+
+public final class com/ably/chat/TypingSetEventType : java/lang/Enum {
+	public static final field SetChanged Lcom/ably/chat/TypingSetEventType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getEventName ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lcom/ably/chat/TypingSetEventType;
+	public static fun values ()[Lcom/ably/chat/TypingSetEventType;
+}
+
+public abstract interface annotation class com/ably/chat/annotations/ChatDsl : java/lang/annotation/Annotation {
+}
+
+public abstract interface annotation class com/ably/chat/annotations/ExperimentalChatApi : java/lang/annotation/Annotation {
+}
+

--- a/chat-android/build.gradle.kts
+++ b/chat-android/build.gradle.kts
@@ -9,6 +9,7 @@ plugins {
     alias(libs.plugins.kover)
     alias(libs.plugins.maven.publish)
     alias(libs.plugins.dokka)
+    alias(libs.plugins.binary.compatibility.validator)
 }
 
 val version = property("VERSION_NAME")

--- a/chat-extensions-compose/api/chat-extensions-compose.api
+++ b/chat-extensions-compose/api/chat-extensions-compose.api
@@ -1,0 +1,38 @@
+public final class com/ably/chat/extensions/compose/ConnectionKt {
+	public static final fun collectAsStatus (Lcom/ably/chat/Connection;Landroidx/compose/runtime/Composer;I)Lcom/ably/chat/ConnectionStatus;
+}
+
+public abstract interface class com/ably/chat/extensions/compose/CurrentOccupancy {
+	public abstract fun getConnections ()I
+	public abstract fun getPresenceMembers ()I
+}
+
+public final class com/ably/chat/extensions/compose/MessagesKt {
+	public static final fun collectAsPagingMessagesState (Lcom/ably/chat/Room;IILandroidx/compose/runtime/Composer;II)Lcom/ably/chat/extensions/compose/PagingMessagesState;
+}
+
+public final class com/ably/chat/extensions/compose/OccupancyKt {
+	public static final fun collectAsOccupancy (Lcom/ably/chat/Room;Landroidx/compose/runtime/Composer;I)Lcom/ably/chat/extensions/compose/CurrentOccupancy;
+}
+
+public abstract interface class com/ably/chat/extensions/compose/PagingMessagesState {
+	public abstract fun getError ()Lio/ably/lib/types/ErrorInfo;
+	public abstract fun getHasMore ()Z
+	public abstract fun getListState ()Landroidx/compose/foundation/lazy/LazyListState;
+	public abstract fun getLoaded ()Landroidx/compose/runtime/snapshots/SnapshotStateList;
+	public abstract fun getLoading ()Z
+	public abstract fun refresh (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/ably/chat/extensions/compose/PresenceKt {
+	public static final fun collectAsPresenceMembers (Lcom/ably/chat/Room;Landroidx/compose/runtime/Composer;I)Ljava/util/List;
+}
+
+public final class com/ably/chat/extensions/compose/RoomKt {
+	public static final fun collectAsStatus (Lcom/ably/chat/Room;Landroidx/compose/runtime/Composer;I)Lcom/ably/chat/RoomStatus;
+}
+
+public final class com/ably/chat/extensions/compose/TypingKt {
+	public static final fun collectAsCurrentlyTyping (Lcom/ably/chat/Room;Landroidx/compose/runtime/Composer;I)Ljava/util/Set;
+}
+

--- a/chat-extensions-compose/build.gradle.kts
+++ b/chat-extensions-compose/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     alias(libs.plugins.maven.publish)
     alias(libs.plugins.compose.compiler)
     alias(libs.plugins.dokka)
+    alias(libs.plugins.binary.compatibility.validator)
 }
 
 val version = property("VERSION_NAME")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,6 +23,7 @@ ktor = "3.0.1"
 molecule = "2.0.0"
 nanohttpd = "2.3.0"
 turbine = "1.2.0"
+binary-compatibility-validator = "0.16.3"
 
 [libraries]
 junit = { group = "junit", name = "junit", version.ref = "junit" }
@@ -76,3 +77,4 @@ build-config = { id = "com.github.gmazzo.buildconfig", version.ref = "build-conf
 kover = { id = "org.jetbrains.kotlinx.kover", version = "0.9.0-RC" }
 maven-publish = { id = "com.vanniktech.maven.publish", version = "0.34.0" }
 dokka = { id = "org.jetbrains.dokka", version = "1.9.20" }
+binary-compatibility-validator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version.ref = "binary-compatibility-validator" }


### PR DESCRIPTION
Introduces initial `chat-android` API interfaces and definitions.