### PR TITLE
feat: add destructuring syntax for subscription handling and history access

### DIFF
--- a/chat/api/android/chat.api
+++ b/chat/api/android/chat.api
@@ -274,10 +274,13 @@ public final class com/ably/chat/MessagesReactionsKt {
 }
 
 public abstract interface class com/ably/chat/MessagesSubscription : com/ably/chat/Subscription {
+	public abstract fun component2 ()Lcom/ably/chat/MessagesSubscription;
 	public abstract fun historyBeforeSubscribe (Ljava/lang/Long;Ljava/lang/Long;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class com/ably/chat/MessagesSubscription$DefaultImpls {
+	public static fun component1 (Lcom/ably/chat/MessagesSubscription;)Lkotlin/jvm/functions/Function0;
+	public static fun component2 (Lcom/ably/chat/MessagesSubscription;)Lcom/ably/chat/MessagesSubscription;
 	public static synthetic fun historyBeforeSubscribe$default (Lcom/ably/chat/MessagesSubscription;Ljava/lang/Long;Ljava/lang/Long;ILkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
@@ -582,7 +585,12 @@ public final class com/ably/chat/RoomsKt {
 }
 
 public abstract interface class com/ably/chat/Subscription {
+	public abstract fun component1 ()Lkotlin/jvm/functions/Function0;
 	public abstract fun unsubscribe ()V
+}
+
+public final class com/ably/chat/Subscription$DefaultImpls {
+	public static fun component1 (Lcom/ably/chat/Subscription;)Lkotlin/jvm/functions/Function0;
 }
 
 public abstract interface class com/ably/chat/Typing {

--- a/chat/api/jvm/chat.api
+++ b/chat/api/jvm/chat.api
@@ -274,10 +274,13 @@ public final class com/ably/chat/MessagesReactionsKt {
 }
 
 public abstract interface class com/ably/chat/MessagesSubscription : com/ably/chat/Subscription {
+	public abstract fun component2 ()Lcom/ably/chat/MessagesSubscription;
 	public abstract fun historyBeforeSubscribe (Ljava/lang/Long;Ljava/lang/Long;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class com/ably/chat/MessagesSubscription$DefaultImpls {
+	public static fun component1 (Lcom/ably/chat/MessagesSubscription;)Lkotlin/jvm/functions/Function0;
+	public static fun component2 (Lcom/ably/chat/MessagesSubscription;)Lcom/ably/chat/MessagesSubscription;
 	public static synthetic fun historyBeforeSubscribe$default (Lcom/ably/chat/MessagesSubscription;Ljava/lang/Long;Ljava/lang/Long;ILkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
@@ -582,7 +585,12 @@ public final class com/ably/chat/RoomsKt {
 }
 
 public abstract interface class com/ably/chat/Subscription {
+	public abstract fun component1 ()Lkotlin/jvm/functions/Function0;
 	public abstract fun unsubscribe ()V
+}
+
+public final class com/ably/chat/Subscription$DefaultImpls {
+	public static fun component1 (Lcom/ably/chat/Subscription;)Lkotlin/jvm/functions/Function0;
 }
 
 public abstract interface class com/ably/chat/Typing {

--- a/chat/src/commonMain/kotlin/com/ably/chat/Messages.kt
+++ b/chat/src/commonMain/kotlin/com/ably/chat/Messages.kt
@@ -318,6 +318,17 @@ public interface MessagesSubscription : Subscription {
      * Spec: CHA-M5j
      */
     public suspend fun historyBeforeSubscribe(start: Long? = null, end: Long? = null, limit: Int = 100): PaginatedResult<Message>
+
+    /**
+     * Syntactic sugar to allow using `historyBeforeSubscribe` with custom `unsubscribe` handle
+     *
+     * @example
+     * ```kotlin
+     * val (unsubscribe, subscription) = messages.subscribe { println(it) }
+     * val previousMessages = subscription.historyBeforeSubscribe()
+     * ```
+     */
+    public operator fun component2(): MessagesSubscription = this
 }
 
 internal class DefaultMessagesSubscription(

--- a/chat/src/commonMain/kotlin/com/ably/chat/Subscription.kt
+++ b/chat/src/commonMain/kotlin/com/ably/chat/Subscription.kt
@@ -21,4 +21,21 @@ public fun interface Subscription {
      * that references to the subscriber are cleaned up.
      */
     public fun unsubscribe()
+
+    /**
+     * Syntactic sugar to allow using custom name for `unsubscribe` handling
+     *
+     * @example
+     * ```kotlin
+     * val (off) = someService.on { println(it) }
+     * off()
+     * val (unsubscribe) = someService.subscribe { println(it) }
+     * unsubscribe()
+     * val (dispose) = someService.addListener { println(it) }
+     * dispose()
+     * ```
+     */
+    public operator fun component1(): () -> Unit = {
+        this.unsubscribe()
+    }
 }

--- a/chat/src/commonTest/kotlin/com/ably/chat/MessagesTest.kt
+++ b/chat/src/commonTest/kotlin/com/ably/chat/MessagesTest.kt
@@ -208,9 +208,9 @@ class MessagesTest {
      */
     @Test
     fun `should throw an exception for listener history if not subscribed`() = runTest {
-        val subscription = messages.subscribe {}
+        val (unsubscribe, subscription) = messages.subscribe {}
 
-        subscription.unsubscribe()
+        unsubscribe()
 
         val exception = assertThrows(AblyException::class.java) {
             runBlocking { subscription.historyBeforeSubscribe() }


### PR DESCRIPTION
Introduces `component1` and `component2` functions for more concise subscription management and history retrieval in `Subscription` and `Messages`. See examples:

```kotlin
val (off) = someService.on { println(it) }
off()
val (unsubscribe, subscription) = messages.subscribe { println(it) }
val previousMessages = subscription.historyBeforeSubscribe()
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Subscriptions now support destructuring: subscribe returns an (unsubscribe, subscription) pair for simpler cleanup.
  * A shorthand unsubscribe function is provided as the first component for easy teardown.
  * Message subscription remains available as the second component; existing usage stays valid (destructuring is optional).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->