### PR TITLE
[ECO-5484] chore: loosen validation for `Occupancy` for better future changes compatibility

### DIFF
--- a/chat/src/commonMain/kotlin/com/ably/chat/ChatApi.kt
+++ b/chat/src/commonMain/kotlin/com/ably/chat/ChatApi.kt
@@ -112,30 +112,30 @@ internal class ChatApi(
     }
 
     private fun tryParseMessageResponse(json: JsonValue): Message? {
-        val messageJsonObject = json.tryAsJsonObject() ?: return null
+        val messageJsonObject = json.jsonObjectOrNull() ?: return null
         val action = messageJsonObject[MessageProperty.Action]
-            ?.tryAsString()?.let { name -> messageActionNameToAction[name] } ?: MessageAction.MESSAGE_CREATE
-        val version = messageJsonObject[MessageProperty.Version]?.tryAsJsonObject()
-        val reactions = messageJsonObject[MessageProperty.Reactions]?.tryAsJsonObject()
-        val text = messageJsonObject[MessageProperty.Text]?.tryAsString() ?: ""
-        val messageSerial = messageJsonObject[MessageProperty.Serial]?.tryAsString() ?: return null
-        val messageClientId = messageJsonObject[MessageProperty.ClientId]?.tryAsString() ?: return null
-        val messageTimestamp = messageJsonObject[MessageProperty.Timestamp]?.tryAsLong() ?: return null
+            ?.stringOrNull()?.let { name -> messageActionNameToAction[name] } ?: MessageAction.MESSAGE_CREATE
+        val version = messageJsonObject[MessageProperty.Version]?.jsonObjectOrNull()
+        val reactions = messageJsonObject[MessageProperty.Reactions]?.jsonObjectOrNull()
+        val text = messageJsonObject[MessageProperty.Text]?.stringOrNull() ?: ""
+        val messageSerial = messageJsonObject[MessageProperty.Serial]?.stringOrNull() ?: return null
+        val messageClientId = messageJsonObject[MessageProperty.ClientId]?.stringOrNull() ?: return null
+        val messageTimestamp = messageJsonObject[MessageProperty.Timestamp]?.longOrNull() ?: return null
 
         return DefaultMessage(
             serial = messageSerial,
             clientId = messageClientId,
             text = text,
             timestamp = messageTimestamp,
-            metadata = messageJsonObject[MessageProperty.Metadata]?.tryAsJsonObject() ?: MessageMetadata(),
+            metadata = messageJsonObject[MessageProperty.Metadata]?.jsonObjectOrNull() ?: MessageMetadata(),
             headers = messageJsonObject.get(MessageProperty.Headers)?.toMap() ?: mapOf(),
             action = action,
             reactions = buildMessageReactions(reactions),
             version = DefaultMessageVersion(
-                serial = version?.get(MessageVersionProperty.Serial)?.tryAsString() ?: messageSerial,
-                timestamp = version?.get(MessageVersionProperty.Timestamp)?.tryAsLong() ?: messageTimestamp,
-                clientId = version?.get(MessageVersionProperty.ClientId)?.tryAsString(),
-                description = version?.get(MessageVersionProperty.Description)?.tryAsString(),
+                serial = version?.get(MessageVersionProperty.Serial)?.stringOrNull() ?: messageSerial,
+                timestamp = version?.get(MessageVersionProperty.Timestamp)?.longOrNull() ?: messageTimestamp,
+                clientId = version?.get(MessageVersionProperty.ClientId)?.stringOrNull(),
+                description = version?.get(MessageVersionProperty.Description)?.stringOrNull(),
                 metadata = version?.get(MessageVersionProperty.Metadata)?.toMap(),
             ),
         )
@@ -149,8 +149,8 @@ internal class ChatApi(
         return this.makeAuthorizedRequest("/chat/$CHAT_API_PROTOCOL_VERSION/rooms/$roomName/occupancy", HttpMethod.Get)?.let {
             logger.debug("getOccupancy();", context = mapOf("roomName" to roomName, "response" to it.toString()))
             DefaultOccupancyData(
-                connections = it.requireInt("connections"),
-                presenceMembers = it.requireInt("presenceMembers"),
+                connections = it.getOrNull("connections")?.intOrNull() ?: 0,
+                presenceMembers = it.getOrNull("presenceMembers")?.intOrNull() ?: 0,
             )
         } ?: throw serverError("Occupancy endpoint returned empty value")
     }

--- a/chat/src/commonMain/kotlin/com/ably/chat/JsonUtils.kt
+++ b/chat/src/commonMain/kotlin/com/ably/chat/JsonUtils.kt
@@ -11,26 +11,31 @@ import io.ably.lib.http.HttpUtils
 import io.ably.lib.types.AblyException
 import io.ably.lib.types.ErrorInfo
 
-internal fun JsonValue.tryAsString(): String? = when (this) {
+internal fun JsonValue.stringOrNull(): String? = when (this) {
     is JsonString -> this.value
     is JsonNumber -> this.value.toString()
     is JsonBoolean -> this.value.toString()
     else -> null
 }
 
-internal fun JsonValue.tryAsLong(): Long? = when (this) {
+internal fun JsonValue.longOrNull(): Long? = when (this) {
     is JsonString -> safeCastToNumber { this.value.toLong() }
     is JsonNumber -> this.value.toLong()
     else -> null
 }
 
-internal fun JsonValue.tryAsInt(): Int? = when (this) {
+internal fun JsonValue.intOrNull(): Int? = when (this) {
     is JsonString -> safeCastToNumber { this.value.toInt() }
     is JsonNumber -> this.value.toInt()
     else -> null
 }
 
-internal fun JsonValue.tryAsJsonObject(): JsonObject? = when (this) {
+internal fun JsonValue.getOrNull(field: String): JsonValue? = when (this) {
+    is JsonObject -> get(field)
+    else -> null
+}
+
+internal fun JsonValue.jsonObjectOrNull(): JsonObject? = when (this) {
     is JsonObject -> this
     else -> null
 }
@@ -45,7 +50,7 @@ internal fun Map<String, String>.toJson() = jsonObject {
 internal fun JsonValue.toMap(): Map<String, String> = when (this) {
     is JsonObject -> buildMap {
         this@toMap.forEach {
-            it.value.tryAsString()?.let { value -> put(it.key, value) }
+            it.value.stringOrNull()?.let { value -> put(it.key, value) }
         }
     }
 
@@ -61,21 +66,14 @@ internal fun JsonValue.requireJsonObject(): JsonObject {
 
 internal fun JsonValue.requireString(memberName: String): String {
     val memberElement = requireField(memberName)
-    return memberElement.tryAsString() ?: throw serverError(
+    return memberElement.stringOrNull() ?: throw serverError(
         "Required string field \"$memberName\" is not a valid string",
     )
 }
 
 internal fun JsonValue.requireLong(memberName: String): Long {
     val memberElement = requireField(memberName)
-    return memberElement.tryAsLong() ?: throw serverError(
-        "Required numeric field \"$memberName\" is not a valid number",
-    )
-}
-
-internal fun JsonValue.requireInt(memberName: String): Int {
-    val memberElement = requireField(memberName)
-    return memberElement.tryAsInt() ?: throw serverError(
+    return memberElement.longOrNull() ?: throw serverError(
         "Required numeric field \"$memberName\" is not a valid number",
     )
 }

--- a/chat/src/commonMain/kotlin/com/ably/chat/Messages.kt
+++ b/chat/src/commonMain/kotlin/com/ably/chat/Messages.kt
@@ -438,7 +438,7 @@ internal class DefaultMessages(
                 serial = pubSubMessage.serial,
                 text = data.text,
                 metadata = data.metadata ?: MessageMetadata(),
-                headers = pubSubMessage.extras?.asJsonObject()?.tryAsJsonValue()?.tryAsJsonObject()?.get("headers")?.toMap() ?: mapOf(),
+                headers = pubSubMessage.extras?.asJsonObject()?.tryAsJsonValue()?.jsonObjectOrNull()?.get("headers")?.toMap() ?: mapOf(),
                 action = pubSubMessage.action,
                 version = DefaultMessageVersion(
                     serial = pubSubMessage.version.serial ?: pubSubMessage.serial,
@@ -566,6 +566,6 @@ private fun parsePubSubMessageData(action: ChatMessageEventType, data: Any): Pub
 
     return PubSubMessageData(
         text = text,
-        metadata = json.tryAsJsonObject()?.get("metadata")?.tryAsJsonObject(),
+        metadata = json.jsonObjectOrNull()?.get("metadata")?.jsonObjectOrNull(),
     )
 }

--- a/chat/src/commonMain/kotlin/com/ably/chat/Occupancy.kt
+++ b/chat/src/commonMain/kotlin/com/ably/chat/Occupancy.kt
@@ -215,7 +215,7 @@ internal class DefaultOccupancy(
             return
         }
 
-        val metrics = data.tryAsJsonObject()?.get("metrics")
+        val metrics = data.jsonObjectOrNull()?.get("metrics")
 
         if (metrics == null) {
             logger.error(
@@ -228,7 +228,7 @@ internal class DefaultOccupancy(
             return
         }
 
-        val connections = metrics.tryAsJsonObject()?.get("connections")?.tryAsInt()
+        val connections = metrics.jsonObjectOrNull()?.get("connections")?.intOrNull()
 
         if (connections == null) {
             logger.error(
@@ -241,7 +241,7 @@ internal class DefaultOccupancy(
             return
         }
 
-        val presenceMembers = metrics.tryAsJsonObject()?.get("presenceMembers")?.tryAsInt()
+        val presenceMembers = metrics.jsonObjectOrNull()?.get("presenceMembers")?.intOrNull()
 
         if (presenceMembers == null) {
             logger.error(

--- a/chat/src/commonMain/kotlin/com/ably/chat/Presence.kt
+++ b/chat/src/commonMain/kotlin/com/ably/chat/Presence.kt
@@ -155,7 +155,7 @@ internal class DefaultPresence(
             DefaultPresenceMember(
                 clientId = user.clientId,
                 connectionId = user.connectionId,
-                data = user.data.tryAsJsonValue()?.tryAsJsonObject(),
+                data = user.data.tryAsJsonValue()?.jsonObjectOrNull(),
                 updatedAt = user.timestamp,
             )
         }
@@ -190,7 +190,7 @@ internal class DefaultPresence(
                 clientId = it.clientId,
                 connectionId = it.connectionId,
                 updatedAt = it.timestamp,
-                data = it.data.tryAsJsonValue()?.tryAsJsonObject(),
+                data = it.data.tryAsJsonValue()?.jsonObjectOrNull(),
             )
             val presenceEvent = DefaultPresenceEvent(
                 type = PresenceEventType.fromPresenceAction(it.action),

--- a/chat/src/commonMain/kotlin/com/ably/chat/RoomReactions.kt
+++ b/chat/src/commonMain/kotlin/com/ably/chat/RoomReactions.kt
@@ -167,7 +167,7 @@ internal class DefaultRoomReactions(
                 name = data.requireString("name"),
                 createdAt = pubSubMessage.timestamp,
                 clientId = pubSubMessage.clientId,
-                metadata = data.tryAsJsonObject()?.get("metadata")?.tryAsJsonObject() ?: ReactionMetadata(),
+                metadata = data.jsonObjectOrNull()?.get("metadata")?.jsonObjectOrNull() ?: ReactionMetadata(),
                 headers = pubSubMessage.extras?.asJsonObject()?.get("headers")?.tryAsJsonValue()?.toMap() ?: mapOf(),
                 isSelf = pubSubMessage.clientId == room.clientId,
             )

--- a/chat/src/commonTest/kotlin/com/ably/chat/ChatApiTest.kt
+++ b/chat/src/commonTest/kotlin/com/ably/chat/ChatApiTest.kt
@@ -180,7 +180,7 @@ class ChatApiTest {
      * @nospec
      */
     @Test
-    fun `getOccupancy should throw exception if 'connections' field is not presented`() = runTest {
+    fun `getOccupancy should return 0 if field is not presented`() = runTest {
         mockOccupancyApiResponse(
             realtime,
             jsonObject {
@@ -188,8 +188,9 @@ class ChatApiTest {
             },
         )
 
-        assertThrows(AblyException::class.java) {
-            runBlocking { chatApi.getOccupancy("roomName") }
-        }
+        assertEquals(
+            DefaultOccupancyData(0, 1_000),
+            chatApi.getOccupancy("roomName"),
+        )
     }
 }


### PR DESCRIPTION
Resolves https://github.com/ably/ably-chat-kotlin/issues/152

- loosen validation for `Occupancy` for better future changes compatibility
- replaced `tryAs*` methods with `*OrNull` alternatives (more common in the Kotlin standard library)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Parsing is more tolerant: missing message fields, timestamps, reactions, presence data, and occupancy counts no longer cause failures; sensible defaults and early-safe exits ensure consistent display.
  - Metadata and headers handling is more robust to prevent null-related errors.

- Refactor
  - Internal JSON parsing functions renamed and standardized for consistent null-safe behavior with no public API changes.

- Tests
  - Occupancy test updated to expect default occupancy when counts are absent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->