### PR TITLE
refactor!: update Kotlin version and simplify JVM compiler options setup

### DIFF
--- a/chat-extensions-compose/build.gradle.kts
+++ b/chat-extensions-compose/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.android.kotlin)
@@ -33,12 +35,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
-    }
-
-    kotlinOptions {
-        jvmTarget = "1.8"
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
     @Suppress("UnstableApiUsage")
@@ -51,6 +49,12 @@ android {
 
 kotlin {
     explicitApi()
+
+    jvmToolchain(17)
+
+    compilerOptions {
+        jvmTarget = JvmTarget.JVM_17
+    }
 }
 
 dependencies {

--- a/chat/api/android/chat.api
+++ b/chat/api/android/chat.api
@@ -227,18 +227,15 @@ public abstract interface class com/ably/chat/MessageVersion {
 
 public abstract interface class com/ably/chat/Messages {
 	public abstract fun delete (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun delete$default (Lcom/ably/chat/Messages;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public abstract fun getChannel ()Lio/ably/lib/realtime/Channel;
 	public abstract fun getReactions ()Lcom/ably/chat/MessagesReactions;
 	public abstract fun history (Ljava/lang/Long;Ljava/lang/Long;ILcom/ably/chat/OrderBy;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun history$default (Lcom/ably/chat/Messages;Ljava/lang/Long;Ljava/lang/Long;ILcom/ably/chat/OrderBy;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public abstract fun send (Ljava/lang/String;Lcom/ably/chat/json/JsonObject;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun send$default (Lcom/ably/chat/Messages;Ljava/lang/String;Lcom/ably/chat/json/JsonObject;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public abstract fun subscribe (Lcom/ably/chat/Messages$Listener;)Lcom/ably/chat/MessagesSubscription;
 	public abstract fun update (Ljava/lang/String;Ljava/lang/String;Lcom/ably/chat/json/JsonObject;Ljava/util/Map;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-}
-
-public final class com/ably/chat/Messages$DefaultImpls {
-	public static synthetic fun delete$default (Lcom/ably/chat/Messages;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public static synthetic fun history$default (Lcom/ably/chat/Messages;Ljava/lang/Long;Ljava/lang/Long;ILcom/ably/chat/OrderBy;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public static synthetic fun send$default (Lcom/ably/chat/Messages;Ljava/lang/String;Lcom/ably/chat/json/JsonObject;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static synthetic fun update$default (Lcom/ably/chat/Messages;Ljava/lang/String;Ljava/lang/String;Lcom/ably/chat/json/JsonObject;Ljava/util/Map;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
@@ -256,14 +253,11 @@ public final class com/ably/chat/MessagesKt {
 
 public abstract interface class com/ably/chat/MessagesReactions {
 	public abstract fun delete (Ljava/lang/String;Ljava/lang/String;Lcom/ably/chat/MessageReactionType;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun delete$default (Lcom/ably/chat/MessagesReactions;Ljava/lang/String;Ljava/lang/String;Lcom/ably/chat/MessageReactionType;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public abstract fun send (Ljava/lang/String;Ljava/lang/String;Lcom/ably/chat/MessageReactionType;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun send$default (Lcom/ably/chat/MessagesReactions;Ljava/lang/String;Ljava/lang/String;Lcom/ably/chat/MessageReactionType;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public abstract fun subscribe (Lcom/ably/chat/MessagesReactions$Listener;)Lcom/ably/chat/Subscription;
 	public abstract fun subscribeRaw (Lcom/ably/chat/MessagesReactions$MessageRawReactionListener;)Lcom/ably/chat/Subscription;
-}
-
-public final class com/ably/chat/MessagesReactions$DefaultImpls {
-	public static synthetic fun delete$default (Lcom/ably/chat/MessagesReactions;Ljava/lang/String;Ljava/lang/String;Lcom/ably/chat/MessageReactionType;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public static synthetic fun send$default (Lcom/ably/chat/MessagesReactions;Ljava/lang/String;Ljava/lang/String;Lcom/ably/chat/MessageReactionType;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public abstract interface class com/ably/chat/MessagesReactions$Listener {
@@ -282,13 +276,8 @@ public final class com/ably/chat/MessagesReactionsKt {
 }
 
 public abstract interface class com/ably/chat/MessagesSubscription : com/ably/chat/Subscription {
-	public abstract fun component2 ()Lcom/ably/chat/MessagesSubscription;
+	public fun component2 ()Lcom/ably/chat/MessagesSubscription;
 	public abstract fun historyBeforeSubscribe (Ljava/lang/Long;Ljava/lang/Long;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
-}
-
-public final class com/ably/chat/MessagesSubscription$DefaultImpls {
-	public static fun component1 (Lcom/ably/chat/MessagesSubscription;)Lkotlin/jvm/functions/Function0;
-	public static fun component2 (Lcom/ably/chat/MessagesSubscription;)Lcom/ably/chat/MessagesSubscription;
 	public static synthetic fun historyBeforeSubscribe$default (Lcom/ably/chat/MessagesSubscription;Ljava/lang/Long;Ljava/lang/Long;ILkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
@@ -404,18 +393,15 @@ public abstract interface class com/ably/chat/PaginatedResult {
 
 public abstract interface class com/ably/chat/Presence {
 	public abstract fun enter (Lcom/ably/chat/json/JsonObject;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun enter$default (Lcom/ably/chat/Presence;Lcom/ably/chat/json/JsonObject;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public abstract fun get (ZLjava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun get$default (Lcom/ably/chat/Presence;ZLjava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public abstract fun getChannel ()Lio/ably/lib/realtime/Channel;
 	public abstract fun isUserPresent (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun leave (Lcom/ably/chat/json/JsonObject;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun leave$default (Lcom/ably/chat/Presence;Lcom/ably/chat/json/JsonObject;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public abstract fun subscribe (Lcom/ably/chat/Presence$Listener;)Lcom/ably/chat/Subscription;
 	public abstract fun update (Lcom/ably/chat/json/JsonObject;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-}
-
-public final class com/ably/chat/Presence$DefaultImpls {
-	public static synthetic fun enter$default (Lcom/ably/chat/Presence;Lcom/ably/chat/json/JsonObject;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public static synthetic fun get$default (Lcom/ably/chat/Presence;ZLjava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public static synthetic fun leave$default (Lcom/ably/chat/Presence;Lcom/ably/chat/json/JsonObject;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static synthetic fun update$default (Lcom/ably/chat/Presence;Lcom/ably/chat/json/JsonObject;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
@@ -538,11 +524,8 @@ public final class com/ably/chat/RoomReactionEventType : java/lang/Enum {
 public abstract interface class com/ably/chat/RoomReactions {
 	public abstract fun getChannel ()Lio/ably/lib/realtime/Channel;
 	public abstract fun send (Ljava/lang/String;Lcom/ably/chat/json/JsonObject;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun subscribe (Lcom/ably/chat/RoomReactions$Listener;)Lcom/ably/chat/Subscription;
-}
-
-public final class com/ably/chat/RoomReactions$DefaultImpls {
 	public static synthetic fun send$default (Lcom/ably/chat/RoomReactions;Ljava/lang/String;Lcom/ably/chat/json/JsonObject;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun subscribe (Lcom/ably/chat/RoomReactions$Listener;)Lcom/ably/chat/Subscription;
 }
 
 public abstract interface class com/ably/chat/RoomReactions$Listener {
@@ -580,12 +563,9 @@ public abstract interface class com/ably/chat/RoomStatusChange {
 
 public abstract interface class com/ably/chat/Rooms {
 	public abstract fun get (Ljava/lang/String;Lcom/ably/chat/RoomOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun get$default (Lcom/ably/chat/Rooms;Ljava/lang/String;Lcom/ably/chat/RoomOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public abstract fun getClientOptions ()Lcom/ably/chat/ChatClientOptions;
 	public abstract fun release (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-}
-
-public final class com/ably/chat/Rooms$DefaultImpls {
-	public static synthetic fun get$default (Lcom/ably/chat/Rooms;Ljava/lang/String;Lcom/ably/chat/RoomOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class com/ably/chat/RoomsKt {
@@ -593,12 +573,8 @@ public final class com/ably/chat/RoomsKt {
 }
 
 public abstract interface class com/ably/chat/Subscription {
-	public abstract fun component1 ()Lkotlin/jvm/functions/Function0;
+	public fun component1 ()Lkotlin/jvm/functions/Function0;
 	public abstract fun unsubscribe ()V
-}
-
-public final class com/ably/chat/Subscription$DefaultImpls {
-	public static fun component1 (Lcom/ably/chat/Subscription;)Lkotlin/jvm/functions/Function0;
 }
 
 public abstract interface class com/ably/chat/Typing {

--- a/chat/api/jvm/chat.api
+++ b/chat/api/jvm/chat.api
@@ -227,18 +227,15 @@ public abstract interface class com/ably/chat/MessageVersion {
 
 public abstract interface class com/ably/chat/Messages {
 	public abstract fun delete (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun delete$default (Lcom/ably/chat/Messages;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public abstract fun getChannel ()Lio/ably/lib/realtime/Channel;
 	public abstract fun getReactions ()Lcom/ably/chat/MessagesReactions;
 	public abstract fun history (Ljava/lang/Long;Ljava/lang/Long;ILcom/ably/chat/OrderBy;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun history$default (Lcom/ably/chat/Messages;Ljava/lang/Long;Ljava/lang/Long;ILcom/ably/chat/OrderBy;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public abstract fun send (Ljava/lang/String;Lcom/ably/chat/json/JsonObject;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun send$default (Lcom/ably/chat/Messages;Ljava/lang/String;Lcom/ably/chat/json/JsonObject;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public abstract fun subscribe (Lcom/ably/chat/Messages$Listener;)Lcom/ably/chat/MessagesSubscription;
 	public abstract fun update (Ljava/lang/String;Ljava/lang/String;Lcom/ably/chat/json/JsonObject;Ljava/util/Map;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-}
-
-public final class com/ably/chat/Messages$DefaultImpls {
-	public static synthetic fun delete$default (Lcom/ably/chat/Messages;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public static synthetic fun history$default (Lcom/ably/chat/Messages;Ljava/lang/Long;Ljava/lang/Long;ILcom/ably/chat/OrderBy;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public static synthetic fun send$default (Lcom/ably/chat/Messages;Ljava/lang/String;Lcom/ably/chat/json/JsonObject;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static synthetic fun update$default (Lcom/ably/chat/Messages;Ljava/lang/String;Ljava/lang/String;Lcom/ably/chat/json/JsonObject;Ljava/util/Map;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
@@ -256,14 +253,11 @@ public final class com/ably/chat/MessagesKt {
 
 public abstract interface class com/ably/chat/MessagesReactions {
 	public abstract fun delete (Ljava/lang/String;Ljava/lang/String;Lcom/ably/chat/MessageReactionType;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun delete$default (Lcom/ably/chat/MessagesReactions;Ljava/lang/String;Ljava/lang/String;Lcom/ably/chat/MessageReactionType;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public abstract fun send (Ljava/lang/String;Ljava/lang/String;Lcom/ably/chat/MessageReactionType;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun send$default (Lcom/ably/chat/MessagesReactions;Ljava/lang/String;Ljava/lang/String;Lcom/ably/chat/MessageReactionType;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public abstract fun subscribe (Lcom/ably/chat/MessagesReactions$Listener;)Lcom/ably/chat/Subscription;
 	public abstract fun subscribeRaw (Lcom/ably/chat/MessagesReactions$MessageRawReactionListener;)Lcom/ably/chat/Subscription;
-}
-
-public final class com/ably/chat/MessagesReactions$DefaultImpls {
-	public static synthetic fun delete$default (Lcom/ably/chat/MessagesReactions;Ljava/lang/String;Ljava/lang/String;Lcom/ably/chat/MessageReactionType;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public static synthetic fun send$default (Lcom/ably/chat/MessagesReactions;Ljava/lang/String;Ljava/lang/String;Lcom/ably/chat/MessageReactionType;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public abstract interface class com/ably/chat/MessagesReactions$Listener {
@@ -282,13 +276,8 @@ public final class com/ably/chat/MessagesReactionsKt {
 }
 
 public abstract interface class com/ably/chat/MessagesSubscription : com/ably/chat/Subscription {
-	public abstract fun component2 ()Lcom/ably/chat/MessagesSubscription;
+	public fun component2 ()Lcom/ably/chat/MessagesSubscription;
 	public abstract fun historyBeforeSubscribe (Ljava/lang/Long;Ljava/lang/Long;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
-}
-
-public final class com/ably/chat/MessagesSubscription$DefaultImpls {
-	public static fun component1 (Lcom/ably/chat/MessagesSubscription;)Lkotlin/jvm/functions/Function0;
-	public static fun component2 (Lcom/ably/chat/MessagesSubscription;)Lcom/ably/chat/MessagesSubscription;
 	public static synthetic fun historyBeforeSubscribe$default (Lcom/ably/chat/MessagesSubscription;Ljava/lang/Long;Ljava/lang/Long;ILkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
@@ -404,18 +393,15 @@ public abstract interface class com/ably/chat/PaginatedResult {
 
 public abstract interface class com/ably/chat/Presence {
 	public abstract fun enter (Lcom/ably/chat/json/JsonObject;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun enter$default (Lcom/ably/chat/Presence;Lcom/ably/chat/json/JsonObject;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public abstract fun get (ZLjava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun get$default (Lcom/ably/chat/Presence;ZLjava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public abstract fun getChannel ()Lio/ably/lib/realtime/Channel;
 	public abstract fun isUserPresent (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun leave (Lcom/ably/chat/json/JsonObject;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun leave$default (Lcom/ably/chat/Presence;Lcom/ably/chat/json/JsonObject;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public abstract fun subscribe (Lcom/ably/chat/Presence$Listener;)Lcom/ably/chat/Subscription;
 	public abstract fun update (Lcom/ably/chat/json/JsonObject;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-}
-
-public final class com/ably/chat/Presence$DefaultImpls {
-	public static synthetic fun enter$default (Lcom/ably/chat/Presence;Lcom/ably/chat/json/JsonObject;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public static synthetic fun get$default (Lcom/ably/chat/Presence;ZLjava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public static synthetic fun leave$default (Lcom/ably/chat/Presence;Lcom/ably/chat/json/JsonObject;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static synthetic fun update$default (Lcom/ably/chat/Presence;Lcom/ably/chat/json/JsonObject;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
@@ -538,11 +524,8 @@ public final class com/ably/chat/RoomReactionEventType : java/lang/Enum {
 public abstract interface class com/ably/chat/RoomReactions {
 	public abstract fun getChannel ()Lio/ably/lib/realtime/Channel;
 	public abstract fun send (Ljava/lang/String;Lcom/ably/chat/json/JsonObject;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun subscribe (Lcom/ably/chat/RoomReactions$Listener;)Lcom/ably/chat/Subscription;
-}
-
-public final class com/ably/chat/RoomReactions$DefaultImpls {
 	public static synthetic fun send$default (Lcom/ably/chat/RoomReactions;Ljava/lang/String;Lcom/ably/chat/json/JsonObject;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun subscribe (Lcom/ably/chat/RoomReactions$Listener;)Lcom/ably/chat/Subscription;
 }
 
 public abstract interface class com/ably/chat/RoomReactions$Listener {
@@ -580,12 +563,9 @@ public abstract interface class com/ably/chat/RoomStatusChange {
 
 public abstract interface class com/ably/chat/Rooms {
 	public abstract fun get (Ljava/lang/String;Lcom/ably/chat/RoomOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun get$default (Lcom/ably/chat/Rooms;Ljava/lang/String;Lcom/ably/chat/RoomOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public abstract fun getClientOptions ()Lcom/ably/chat/ChatClientOptions;
 	public abstract fun release (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-}
-
-public final class com/ably/chat/Rooms$DefaultImpls {
-	public static synthetic fun get$default (Lcom/ably/chat/Rooms;Ljava/lang/String;Lcom/ably/chat/RoomOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class com/ably/chat/RoomsKt {
@@ -593,12 +573,8 @@ public final class com/ably/chat/RoomsKt {
 }
 
 public abstract interface class com/ably/chat/Subscription {
-	public abstract fun component1 ()Lkotlin/jvm/functions/Function0;
+	public fun component1 ()Lkotlin/jvm/functions/Function0;
 	public abstract fun unsubscribe ()V
-}
-
-public final class com/ably/chat/Subscription$DefaultImpls {
-	public static fun component1 (Lcom/ably/chat/Subscription;)Lkotlin/jvm/functions/Function0;
 }
 
 public abstract interface class com/ably/chat/Typing {

--- a/chat/build.gradle.kts
+++ b/chat/build.gradle.kts
@@ -1,7 +1,7 @@
 import com.vanniktech.maven.publish.JavadocJar
 import com.vanniktech.maven.publish.KotlinMultiplatform
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
-import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
+import org.jetbrains.kotlin.gradle.dsl.JvmDefaultMode
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
@@ -19,14 +19,21 @@ val version = property("VERSION_NAME")
 kotlin {
     explicitApi()
 
+    jvmToolchain(17)
+
     androidTarget {
-        @OptIn(ExperimentalKotlinGradlePluginApi::class)
         compilerOptions {
             jvmTarget.set(JvmTarget.JVM_1_8)
+            jvmDefault.set(JvmDefaultMode.NO_COMPATIBILITY)
         }
     }
 
-    jvm()
+    jvm {
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_1_8)
+            jvmDefault.set(JvmDefaultMode.NO_COMPATIBILITY)
+        }
+    }
 
     sourceSets {
         commonMain.dependencies {

--- a/chat/src/commonMain/kotlin/com/ably/chat/MessagesReactions.kt
+++ b/chat/src/commonMain/kotlin/com/ably/chat/MessagesReactions.kt
@@ -224,7 +224,7 @@ public interface MessageReactionsSummary {
 /**
  * @see [MessagesReactions.send]
  */
-public suspend fun MessagesReactions.send(message: Message, name: String, type: MessageReactionType? = null, count: Int = 1) =
+public suspend fun MessagesReactions.send(message: Message, name: String, type: MessageReactionType? = null, count: Int = 1): Unit =
     send(
         messageSerial = message.serial,
         name = name,
@@ -235,7 +235,7 @@ public suspend fun MessagesReactions.send(message: Message, name: String, type: 
 /**
  * @see [MessagesReactions.delete]
  */
-public suspend fun MessagesReactions.delete(message: Message, name: String? = null, type: MessageReactionType? = null) =
+public suspend fun MessagesReactions.delete(message: Message, name: String? = null, type: MessageReactionType? = null): Unit =
     delete(
         messageSerial = message.serial,
         name = name,

--- a/chat/src/commonTest/kotlin/com/ably/chat/room/lifecycle/MonitoringTest.kt
+++ b/chat/src/commonTest/kotlin/com/ably/chat/room/lifecycle/MonitoringTest.kt
@@ -199,7 +199,6 @@ class MonitoringTest {
                 ChannelState.detached -> RoomStatus.Detached
                 ChannelState.failed -> RoomStatus.Failed
                 ChannelState.suspended -> RoomStatus.Suspended
-                else -> null
             }
             Assert.assertEquals(expectedRoomStatus, roomStatus)
         }

--- a/detekt.yml
+++ b/detekt.yml
@@ -914,7 +914,7 @@ style:
   OptionalAbstractKeyword:
     active: true
   OptionalUnit:
-    active: true
+    active: false
   PreferToOverPairSyntax:
     active: false
   ProtectedMemberInFinalClass:

--- a/example/build.gradle.kts
+++ b/example/build.gradle.kts
@@ -1,6 +1,7 @@
 import java.io.FileInputStream
 import java.io.InputStreamReader
 import java.util.Properties
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     alias(libs.plugins.android.application)
@@ -36,13 +37,6 @@ android {
             )
         }
     }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
-    }
-    kotlinOptions {
-        jvmTarget = "1.8"
-    }
     buildFeatures {
         buildConfig = true
         compose = true
@@ -54,6 +48,18 @@ android {
         resources {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
         }
+    }
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+}
+
+kotlin {
+    jvmToolchain(17)
+
+    compilerOptions {
+        jvmTarget = JvmTarget.JVM_17
     }
 }
 

--- a/example/src/main/java/com/ably/chat/example/MainActivity.kt
+++ b/example/src/main/java/com/ably/chat/example/MainActivity.kt
@@ -33,6 +33,7 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -152,7 +153,7 @@ fun Chat(room: Room, modifier: Modifier = Modifier) {
     val updating = edited != null
     val coroutineScope = rememberCoroutineScope()
     val paginatedMessages = room.collectAsPagingMessagesState(scrollThreshold = 10, fetchSize = 15)
-    val receivedReactions = remember { mutableListOf<RoomReaction>() }
+    val receivedReactions = remember { mutableStateListOf<RoomReaction>() }
 
     LaunchedEffect(Unit) {
         room.reactions.asFlow().collect {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ ably = "1.4.0"
 junit = "4.13.2"
 agp = "8.5.2"
 detekt = "1.23.6"
-kotlin = "2.0.21"
+kotlin = "2.2.20"
 androidx-test = "1.6.1"
 androidx-junit = "1.2.1"
 core-ktx = "1.13.1"
@@ -20,11 +20,14 @@ mockk = "1.14.6"
 robolectric = "4.16"
 coroutine = "1.9.0"
 build-config = "5.5.1"
-ktor = "3.0.1"
-molecule = "2.0.0"
+ktor = "3.3.0"
+molecule = "2.2.0"
 nanohttpd = "2.3.0"
-turbine = "1.2.0"
-binary-compatibility-validator = "0.16.3"
+turbine = "1.2.1"
+binary-compatibility-validator = "0.18.1"
+dokka = "1.9.20"
+kover = "0.9.2"
+maven-publish = "0.34.0"
 
 [libraries]
 junit = { group = "junit", name = "junit", version.ref = "junit" }
@@ -75,11 +78,11 @@ ktor-client = ["ktor-client-core", "ktor-client-cio"]
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 android-kotlin = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 multiplatform-kotlin = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
+compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 android-library = { id = "com.android.library", version.ref = "agp" }
 android-application = { id = "com.android.application", version.ref = "agp" }
-compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 build-config = { id = "com.github.gmazzo.buildconfig", version.ref = "build-config" }
-kover = { id = "org.jetbrains.kotlinx.kover", version = "0.9.0-RC" }
-maven-publish = { id = "com.vanniktech.maven.publish", version = "0.34.0" }
-dokka = { id = "org.jetbrains.dokka", version = "1.9.20" }
+kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
+maven-publish = { id = "com.vanniktech.maven.publish", version.ref = "maven-publish" }
 binary-compatibility-validator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version.ref = "binary-compatibility-validator" }


### PR DESCRIPTION
- Upgraded Kotlin to version 2.2.20
- Consolidated JVM compiler options under a unified structure in build scripts
- (BREAKING CHANGE for binary compatibility) Removed deprecated synthetic functions and default interface implementations from generated APIs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Public API surface adjusted to flatten Kotlin/JVM default-parameter support (no behavioral changes).

- Chores
  - Upgraded core dependencies (Kotlin 2.2.20, Ktor 3.3.0, Molecule 2.2.0, Turbine 1.2.1, etc.).
  - Build/toolchain standardized to Java 17 across targets.

- Style
  - Disabled OptionalUnit rule and added explicit Unit return annotations where applicable.
  - Example app: reactions list now uses observable Compose state for correct UI updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->